### PR TITLE
Fixed import path of GeneratedWeb3API in index.d.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,12 @@
   "packages": {
     "": {
       "name": "moralis",
-      "version": "0.0.36",
+      "version": "0.0.54",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "7.12.5",
         "@babel/runtime-corejs3": "7.12.5",
+        "@metamask/detect-provider": "^1.2.0",
         "react-native-crypto-js": "1.0.0",
         "uuid": "3.4.0",
         "web3": "^1.3.3",
@@ -2396,6 +2397,14 @@
       "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
       "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==",
       "dev": true
+    },
+    "node_modules/@metamask/detect-provider": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-1.2.0.tgz",
+      "integrity": "sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ==",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@node-rs/bcrypt": {
       "version": "0.4.1",
@@ -23805,6 +23814,11 @@
       "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
       "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==",
       "dev": true
+    },
+    "@metamask/detect-provider": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-1.2.0.tgz",
+      "integrity": "sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ=="
     },
     "@node-rs/bcrypt": {
       "version": "0.4.1",

--- a/types/generated/web3Api.d.ts
+++ b/types/generated/web3Api.d.ts
@@ -324,7 +324,9 @@ export interface components {
       | "bsc"
       | "0x38"
       | "bsc testnet"
-      | "0x61";
+      | "0x61"
+      | "avalanche"
+      | "0xa86a";
     nft: {
       /** The address of the contract of the NFT */
       token_address: string;
@@ -400,6 +402,8 @@ export interface components {
       from_address?: string;
       /** The address that recieved the NFT */
       to_address: string;
+      /** The value that was sent in the transaction (ETH/BNB/etc..) */
+      value?: string;
       /** The number of tokens transferred */
       amount?: string;
       /** The type of NFT contract standard */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter } from 'events';
 import NativeWeb3 from 'web3';
-import { GeneratedWeb3API } from './generated/web3api';
+import { GeneratedWeb3API } from './generated/web3Api';
 
 declare enum ErrorCode {
   OTHER_CAUSE = -1,


### PR DESCRIPTION
Follow up on this problem: https://forum.moralis.io/t/incorrect-spelling-in-the-file-index-d-ts-in-the-import-of-generated-web3api-d-ts/2638

Two commits, first with changed `index.d.ts` file, second with two files that got changed automatically after running `npm install`. I don't know if I should include the second commit. If the second commit should not be included, just merge only the first commit containing the import path fix in `index.d.ts`. Thanks!