### PR TITLE
feat: allow provide list of wallets for connecting via WC

### DIFF
--- a/src/MoralisWalletConnectProvider.js
+++ b/src/MoralisWalletConnectProvider.js
@@ -32,11 +32,13 @@ class MoralisWalletConnectProvider {
         this.provider = new WalletConnectProvider.default({
           rpc: MORALIS_RPCS,
           chainId: options.chainId,
+          mobileLinks: options.mobileLinks,
         });
       } else {
         this.provider = new window.WalletConnectProvider.default({
           rpc: MORALIS_RPCS,
           chainId: options.chainId,
+          mobileLinks: options.mobileLinks,
         });
       }
     }


### PR DESCRIPTION
Added option for providing list of wallets for connecting via WC from mobile phone
Example: 
```
let user = await Moralis.authenticate({
    provider: "walletconnect",
    mobileLinks: [ "rainbow","metamask","argent","trust","imtoken","pillar"  ]
});
```
![image](https://user-images.githubusercontent.com/78314301/134698502-466c4215-6f38-415a-a927-0e5a52dad930.png)


WC docs: https://docs.walletconnect.org/quick-start/dapps/web3-provider#filter-mobile-linking-options