### PR TITLE
fix: propagate plugin errors

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -158,7 +158,8 @@ class MoralisWeb3 {
           if (!options) options = {};
           const response = await run(`${plugin.name}_${f}`, params);
           if (!response.data.success) {
-            throw new Error('Something went wrong', response.data);
+            const error = JSON.stringify(JSON.parse(response.data.data), null, 2);
+            throw new Error(`Something went wrong\n${error}`);
           }
           if (options.disableTriggers !== true) {
             const triggerReturn = await this.handleTriggers(response.data.result.triggers);


### PR DESCRIPTION
CHANGELOG: The errors thrown by plugins built using AST are now correctly propagated 