### PR TITLE
Fix: remove json parser from error propagation

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -158,7 +158,7 @@ class MoralisWeb3 {
           if (!options) options = {};
           const response = await run(`${plugin.name}_${f}`, params);
           if (!response.data.success) {
-            const error = JSON.stringify(JSON.parse(response.data.data), null, 2);
+            const error = JSON.stringify(response.data.data, null, 2);
             throw new Error(`Something went wrong\n${error}`);
           }
           if (options.disableTriggers !== true) {


### PR DESCRIPTION
---
name: 'Pull request'
about: Remove JSON.parse from error propagation
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description
The plugins now throws errors that are objects, therefore parsing them throws an error.

Related issue: #`FILL_THIS_OUT`

### Solution Description

Remove JSON.parse() from error propagation.
