### PR TITLE
Hotfix/support events in moralis transfer function

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -11,6 +11,8 @@ import MoralisInjectedProvider from './MoralisInjectedProvider';
 import TransferUtils from './TransferUtils';
 import { run } from './Cloud';
 import detectEthereumProvider from '@metamask/detect-provider';
+const EventEmitter = require('events');
+const transferEvents = new EventEmitter();
 
 export const EthereumEvents = {
   CONNECT: 'connect',
@@ -242,6 +244,7 @@ class MoralisWeb3 {
     // eslint-disable-next-line camelcase
     token_id,
     system = 'evm',
+    awaitReceipt = true,
   } = {}) {
     // Allow snake-case for backwards compatibility
     // eslint-disable-next-line camelcase
@@ -255,6 +258,7 @@ class MoralisWeb3 {
       amount,
       tokenId,
       system,
+      awaitReceipt,
     };
 
     TransferUtils.isSupportedType(type);
@@ -301,7 +305,24 @@ class MoralisWeb3 {
         throw new Error(`Unknown transfer type: "${type}"`);
     }
 
-    return transferOperation;
+    if (awaitReceipt) return transferOperation;
+
+    transferOperation
+      .on('transactionHash', hash => {
+        transferEvents.emit('transactionHash', hash);
+      })
+      .on('receipt', receipt => {
+        transferEvents.emit('receipt', receipt);
+      })
+      .on('confirmation', (confirmationNumber, receipt) => {
+        transferEvents.emit('confirmation', (confirmationNumber, receipt));
+      })
+      .on('error', error => {
+        transferEvents.emit('error', error);
+        throw error;
+      });
+
+    return transferEvents;
   }
 
   static async executeFunction({ contractAddress, abi, functionName, params = {} } = {}) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -302,6 +302,7 @@ export namespace Moralis {
     tokenId?: string;
     /** @deprecated use tokenId field instead */
     token_id?: string;
+    awaitReceipt?: boolean;
     system?: TransferSystem;
   }
   type TransferResult = unknown;


### PR DESCRIPTION
---
name: 'Hotfix/support events in moralis transfer function'
about: Moralis.transfer
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Moralis.transfer doesn't support the standard transfer events

### Solution Description

Added `awaitReceipt` field to control the output. If `true`, the receipt is returned with no events, if `false`, the events are returned. (It is `true` by default).
