### PR TITLE
feature: Using this.web3 instead of Moralis.Web3() each time

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -260,7 +260,8 @@ class MoralisWeb3 {
     TransferUtils.isSupportedType(type);
     TransferUtils.validateInput(type, options);
 
-    const web3 = await MoralisWeb3.enable();
+    if (!this.ensureWeb3IsInstalled()) throw new Error(ERROR_WEB3_MISSING);
+    const web3 = this.web3;
 
     const sender = await (await web3.eth.getAccounts())[0];
 
@@ -305,7 +306,8 @@ class MoralisWeb3 {
   }
 
   static async executeFunction({ contractAddress, abi, functionName, params = {} } = {}) {
-    const web3 = await MoralisWeb3.enable();
+    if (!this.ensureWeb3IsInstalled()) throw new Error(ERROR_WEB3_MISSING);
+    const web3 = this.web3;
 
     const contractOptions = {};
 

--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -261,7 +261,7 @@ class MoralisWeb3 {
     TransferUtils.validateInput(type, options);
 
     if (!this.ensureWeb3IsInstalled()) throw new Error(ERROR_WEB3_MISSING);
-    const web3 = this.web3;
+    const { web3 } = this;
 
     const sender = await (await web3.eth.getAccounts())[0];
 
@@ -307,7 +307,7 @@ class MoralisWeb3 {
 
   static async executeFunction({ contractAddress, abi, functionName, params = {} } = {}) {
     if (!this.ensureWeb3IsInstalled()) throw new Error(ERROR_WEB3_MISSING);
-    const web3 = this.web3;
+    const { web3 } = this;
 
     const contractOptions = {};
 


### PR DESCRIPTION
---
name: 'feature/global_web3objectt'
about: Moralis global web3 provider for web3 methods
---

## feature/global_web3object

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

`Moralis.transfer()` and `Moralis.executeFunction()` enable `Moralis.Web3()` only for metamask.


### Solution Description

Instead of using `Moralis.Web3()` each time use:
```
if (!this.ensureWeb3IsInstalled()) throw new Error(ERROR_WEB3_MISSING);
const web3 = this.web3;
```
