### PR TITLE
[fix] ethereum.enable deprecation warning (EIP-1102)

### DIFF
--- a/src/MoralisInjectedProvider.js
+++ b/src/MoralisInjectedProvider.js
@@ -15,7 +15,9 @@ async function getWeb3FromBrowser() {
 
   if (ethereum) {
     const web3 = new MWeb3(ethereum);
-    await ethereum.enable();
+    await ethereum.request({
+      method: "eth_requestAccounts",
+    });
     return web3;
   }
   if (provider) {


### PR DESCRIPTION
---
name: 'fix/connect_metamask'
about: Update ethereum.enable() to the latest standard (eip-1102)
---

## fix/connect_metamask

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Moralis.enable() uses ethereum.enable() when connecting to Metamask. According to EIP1102, this method is deprecated and may be removed in the future.

### Solution Description

Updated to the new method: ethereum.request

