### PR TITLE
quickfix: Update web3Api.d.ts

### DIFF
--- a/types/generated/web3Api.d.ts
+++ b/types/generated/web3Api.d.ts
@@ -1590,7 +1590,7 @@ export class GeneratedWeb3API {
     resolveDomain: (options: operations["resolveDomain"]["parameters"]["query"] & operations["resolveDomain"]["parameters"]["path"]) => Promise<operations["resolveDomain"]["responses"]["200"]["content"]["application/json"]>;
   }
 
-  static ethDefi: {
+  static defi: {
     getPairReserves: (options: operations["getPairReserves"]["parameters"]["query"] & operations["getPairReserves"]["parameters"]["path"]) => Promise<operations["getPairReserves"]["responses"]["200"]["content"]["application/json"]>;
     getPairAddress: (options: operations["getPairAddress"]["parameters"]["query"] & operations["getPairAddress"]["parameters"]["path"]) => Promise<operations["getPairAddress"]["responses"]["200"]["content"]["application/json"]>;
   }

--- a/types/generated/web3Api.d.ts
+++ b/types/generated/web3Api.d.ts
@@ -1590,7 +1590,7 @@ export class GeneratedWeb3API {
     resolveDomain: (options: operations["resolveDomain"]["parameters"]["query"] & operations["resolveDomain"]["parameters"]["path"]) => Promise<operations["resolveDomain"]["responses"]["200"]["content"]["application/json"]>;
   }
 
-  static eth-defi: {
+  static ethDefi: {
     getPairReserves: (options: operations["getPairReserves"]["parameters"]["query"] & operations["getPairReserves"]["parameters"]["path"]) => Promise<operations["getPairReserves"]["responses"]["200"]["content"]["application/json"]>;
     getPairAddress: (options: operations["getPairAddress"]["parameters"]["query"] & operations["getPairAddress"]["parameters"]["path"]) => Promise<operations["getPairAddress"]["responses"]["200"]["content"]["application/json"]>;
   }


### PR DESCRIPTION
---
Name: **Update web3Api.d.ts**
About: **Rename eth-defi to ethDefi**
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: Projects made on Typescript and Next.js crashed after `npm run build` due to invalid name `eth-defi`.
![image](https://user-images.githubusercontent.com/78314301/136194010-d703e5e3-da24-47f2-9913-6a822c5cd43e.png)


### Solution Description

Changing the `eth-defi` name to `defi`.
