### PR TITLE
automatic_web3_address_in_web3api

### DIFF
--- a/scripts/genWeb3API.js
+++ b/scripts/genWeb3API.js
@@ -19,10 +19,14 @@ content += `/**
 
 content += `const axios = require('axios');\n`;
 
+// content += `const Web3 = require('web3');\n`;
+// content += `const MoralisWeb3 = require('./MoralisWeb3').default;\n`;
+
 content += `
 class Web3Api {
-  static initialize(serverUrl) {
+  static initialize(serverUrl, web3 = {}) {
     this.serverUrl = serverUrl;
+    this.web3 = web3;
   }
 
   static async apiCall(name, options) {
@@ -30,9 +34,16 @@ class Web3Api {
       throw new Error('Web3Api not initialized, run Web3Api.initialize first');
     }
 
+    if(this.web3.eth) {
+      if (!options.address) {
+        options.address = await (await this.web3.eth.getAccounts())[0];
+      }
+    }
+
     try {
       const http = axios.create({ baseURL: this.serverUrl });
       if (!options.chain) options.chain = 'eth';
+      
       const response =  await http.post(\`/functions/\${name}\`, options, {
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
       });
@@ -124,7 +135,8 @@ const genWebApi = async () => {
   content += '}\n';
   content += '\n';
 
-  content += 'export default Web3Api;\n';
+  // content += 'export default Web3Api;\n';
+  content += 'module.exports = Web3Api;\n';
 
   const outputDirectory = path.join(__dirname, OUTPUT_DIRECTORY);
   const outputFile = path.join(outputDirectory, OUTPUT_FILENAME);

--- a/src/MoralisWeb3Api.js
+++ b/src/MoralisWeb3Api.js
@@ -5,8 +5,9 @@
 const axios = require('axios');
 
 class Web3Api {
-  static initialize(serverUrl) {
+  static initialize(serverUrl, web3 = {}) {
     this.serverUrl = serverUrl;
+    this.web3 = web3;
   }
 
   static async apiCall(name, options) {
@@ -14,9 +15,16 @@ class Web3Api {
       throw new Error('Web3Api not initialized, run Web3Api.initialize first');
     }
 
+    if(this.web3.eth) {
+      if (!options.address) {
+        options.address = await (await this.web3.eth.getAccounts())[0];
+      }
+    }
+
     try {
       const http = axios.create({ baseURL: this.serverUrl });
       if (!options.chain) options.chain = 'eth';
+      
       const response =  await http.post(`/functions/${name}`, options, {
         headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
       });
@@ -73,6 +81,10 @@ class Web3Api {
     getPairReserves: async (options = {}) => Web3Api.apiCall('getPairReserves', options),
     getPairAddress: async (options = {}) => Web3Api.apiCall('getPairAddress', options),
   }
+
+  static storage = {
+    uploadFolder: async (options = {}) => Web3Api.apiCall('uploadFolder', options),
+  }
 }
 
-export default Web3Api;
+module.exports = Web3Api;

--- a/src/Parse.js
+++ b/src/Parse.js
@@ -41,7 +41,7 @@ class Moralis extends MoralisWeb3 {
     }
     this.initialize(appId);
     this.serverURL = serverUrl;
-    this.Web3API.initialize(serverUrl);
+    this.Web3API.initialize(serverUrl, this.web3);
     await this.initPlugins(plugins);
   }
 


### PR DESCRIPTION
---
name: 'Automatic web3 address in web3api'
about: Automatic web3 address in web3api
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Current address doesn't get added to the Web3Api functions


### Solution Description

Current address gets fetched from the web3 instance that gets passed into the Web3Api initialize function.

`Web3Api.initialize(serverUrl, web3);`

`Moralis.start({appId, serverUrl})` uses the web3 instance when `await Moralis.enable(options);` is executed;
