### PR TITLE
Update: Add plugin response propagation

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -176,7 +176,10 @@ class MoralisWeb3 {
             throw new Error(`Something went wrong\n${error}`);
           }
           if (options.disableTriggers !== true) {
-            const triggerReturn = await this.handleTriggers(response.data.result.triggers, response.data.result.data);
+            const triggerReturn = await this.handleTriggers(
+              response.data.result.triggers,
+              response.data.result.data
+            );
             if (triggerReturn) return triggerReturn;
           }
           return response.data.result;
@@ -200,7 +203,8 @@ class MoralisWeb3 {
             response = window.open(triggersArray[i]?.data);
           if (triggersArray[i]?.options?.newTab === false)
             response = window.open(triggersArray[i]?.data, '_self');
-          if (triggersArray[i]?.shouldReturnPayload === true) return { payload: payload, response: response };
+          if (triggersArray[i]?.shouldReturnPayload === true)
+            return { payload: payload, response: response };
           if (triggersArray[i]?.shouldReturnResponse === true) return response;
           break;
         // Handles `web3Transaction` trigger
@@ -210,7 +214,8 @@ class MoralisWeb3 {
             response = await this.web3.eth.sendTransaction(triggersArray[i]?.data);
           if (triggersArray[i]?.shouldAwait === false)
             response = this.web3.eth.sendTransaction(triggersArray[i]?.data);
-          if (triggersArray[i]?.shouldReturnPayload === true) return { payload: payload, response: response };
+          if (triggersArray[i]?.shouldReturnPayload === true)
+            return { payload: payload, response: response };
           if (triggersArray[i]?.shouldReturnResponse === true) return response;
           break;
         // Handles `web3Sign` trigger
@@ -230,7 +235,8 @@ class MoralisWeb3 {
               triggersArray[i].message,
               triggersArray[i].signer
             );
-          if (triggersArray[i]?.shouldReturnPayload === true) return { payload: payload, response: response };
+          if (triggersArray[i]?.shouldReturnPayload === true)
+            return { payload: payload, response: response };
           if (triggersArray[i]?.shouldReturnResponse === true) return response;
           break;
         default:

--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -176,7 +176,7 @@ class MoralisWeb3 {
             throw new Error(`Something went wrong\n${error}`);
           }
           if (options.disableTriggers !== true) {
-            const triggerReturn = await this.handleTriggers(response.data.result.triggers);
+            const triggerReturn = await this.handleTriggers(response.data.result.triggers, response.data.result.data);
             if (triggerReturn) return triggerReturn;
           }
           return response.data.result;
@@ -186,52 +186,55 @@ class MoralisWeb3 {
     this.Plugins = allPlugins;
   }
 
-  static async handleTriggers(_triggersArray) {
-    if (!_triggersArray) return;
-    for (let i = 0; i < _triggersArray.length; i++) {
+  static async handleTriggers(triggersArray, payload) {
+    if (!triggersArray) return;
+    for (let i = 0; i < triggersArray.length; i++) {
       let response;
-      switch (_triggersArray[i]?.name) {
+      switch (triggersArray[i]?.name) {
         // Handles `openUrl` trigger
         case 'openUrl':
           if (
-            _triggersArray[i]?.options?.newTab === true ||
-            !_triggersArray[i]?.options?.hasOwnProperty('newTab')
+            triggersArray[i]?.options?.newTab === true ||
+            !triggersArray[i]?.options?.hasOwnProperty('newTab')
           )
-            response = window.open(_triggersArray[i]?.data);
-          if (_triggersArray[i]?.options?.newTab === false)
-            response = window.open(_triggersArray[i]?.data, '_self');
-          if (_triggersArray[i]?.shouldReturnResponse === true) return response;
+            response = window.open(triggersArray[i]?.data);
+          if (triggersArray[i]?.options?.newTab === false)
+            response = window.open(triggersArray[i]?.data, '_self');
+          if (triggersArray[i]?.shouldReturnPayload === true) return { payload: payload, response: response };
+          if (triggersArray[i]?.shouldReturnResponse === true) return response;
           break;
         // Handles `web3Transaction` trigger
         case 'web3Transaction':
           if (!this.ensureWeb3IsInstalled()) throw new Error(ERROR_WEB3_MISSING);
-          if (_triggersArray[i]?.shouldAwait === true)
-            response = await this.web3.eth.sendTransaction(_triggersArray[i]?.data);
-          if (_triggersArray[i]?.shouldAwait === false)
-            response = this.web3.eth.sendTransaction(_triggersArray[i]?.data);
-          if (_triggersArray[i]?.shouldReturnResponse === true) return response;
+          if (triggersArray[i]?.shouldAwait === true)
+            response = await this.web3.eth.sendTransaction(triggersArray[i]?.data);
+          if (triggersArray[i]?.shouldAwait === false)
+            response = this.web3.eth.sendTransaction(triggersArray[i]?.data);
+          if (triggersArray[i]?.shouldReturnPayload === true) return { payload: payload, response: response };
+          if (triggersArray[i]?.shouldReturnResponse === true) return response;
           break;
         // Handles `web3Sign` trigger
         case 'web3Sign':
           if (!this.ensureWeb3IsInstalled()) throw new Error(ERROR_WEB3_MISSING);
-          if (!_triggersArray[i].message)
+          if (!triggersArray[i].message)
             throw new Error('web3Sign trigger does not have a message to sign');
-          if (!_triggersArray[i].signer || !this.web3.utils.isAddress(_triggersArray[i].signer))
+          if (!triggersArray[i].signer || !this.web3.utils.isAddress(triggersArray[i].signer))
             throw new Error('web3Sign trigger signer address missing or invalid');
-          if (_triggersArray[i]?.shouldAwait === true)
+          if (triggersArray[i]?.shouldAwait === true)
             response = await this.web3.eth.personal.sign(
-              _triggersArray[i].message,
-              _triggersArray[i].signer
+              triggersArray[i].message,
+              triggersArray[i].signer
             );
-          if (_triggersArray[i]?.shouldAwait === false)
+          if (triggersArray[i]?.shouldAwait === false)
             response = this.web3.eth.personal.sign(
-              _triggersArray[i].message,
-              _triggersArray[i].signer
+              triggersArray[i].message,
+              triggersArray[i].signer
             );
-          if (_triggersArray[i]?.shouldReturnResponse === true) return response;
+          if (triggersArray[i]?.shouldReturnPayload === true) return { payload: payload, response: response };
+          if (triggersArray[i]?.shouldReturnResponse === true) return response;
           break;
         default:
-          throw new Error(`Unknown trigger: "${_triggersArray[i]?.name}"`);
+          throw new Error(`Unknown trigger: "${triggersArray[i]?.name}"`);
       }
     }
   }


### PR DESCRIPTION
---
name: 'Pull request'
about: Allow SDK to return results from the plugin, even when a `trigger` is present.
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description
Whenever a plugin returns a `trigger`, the plugin executes it but does not return the plugin response to the developer.
In some cases, devs need the plugin response.


### Solution Description
Enable SDK to return the plugin response even when a trigger is present.