### PR TITLE
Update: Add  trigger and memory card

### DIFF
--- a/src/MoralisWeb3MemoryCard.js
+++ b/src/MoralisWeb3MemoryCard.js
@@ -1,0 +1,31 @@
+class MemoryCard {
+  save(what) {
+    this.saved = what;
+  }
+
+  get(where) {
+    if (!this.saved) throw new Error('Nothing saved to memory card');
+
+    // In case the saved data is not an object but a simple string or number
+    if (where.length === 0) return this.getSaved();
+
+    let tmp;
+    let savedTmp = this.saved;
+    for (let i = 0; i < where.length; i++) {
+      tmp = savedTmp[where[i]];
+      savedTmp = tmp;
+    }
+
+    return savedTmp;
+  }
+
+  getSaved() {
+    return this.saved;
+  }
+
+  deleteSaved() {
+    this.saved = undefined;
+  }
+}
+
+module.exports = { MemoryCard };


### PR DESCRIPTION
---
name: 'Pull request'
about: Add `callPluginEndpoint` trigger and memory card to temporary store data returned by the plugin
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

It is necessary a way to chain multiple triggers (A | B ) where B depends by the result of A.
The logic allows to do so, temporary saving the result of A and use it to call B.
The plugin must return the right settings so that the trigger loop does not end until the chain is completed.

Related issue: #`FILL_THIS_OUT`

### Solution Description

Add `callPluginEndpoint` trigger.
Add new `MemoryCard` class.
