### PR TITLE
fix: events emmiter cleans cache

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -13,8 +13,6 @@ import { run } from './Cloud';
 import detectEthereumProvider from '@metamask/detect-provider';
 import createSigningData from './createSigningData';
 const EventEmitter = require('events');
-const transferEvents = new EventEmitter();
-const contractExecuteEvents = new EventEmitter();
 
 export const EthereumEvents = {
   CONNECT: 'connect',
@@ -511,6 +509,8 @@ class MoralisWeb3 {
 
     if (awaitReceipt) return transferOperation;
 
+    const transferEvents = new EventEmitter();
+
     transferOperation
       .on('transactionHash', hash => {
         transferEvents.emit('transactionHash', hash);
@@ -584,6 +584,8 @@ class MoralisWeb3 {
       : customFunction(...Object.values(parsedInputs)).send(msgValue ? { value: msgValue } : null);
 
     if (awaitReceipt) return response;
+
+    const contractExecuteEvents = new EventEmitter();
 
     response
       .on('transactionHash', hash => {


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Events emmiter shows previos event+new events because it wasn't defined in the function scope.

### Solution Description

<!-- Add a description of the solution in this PR. -->

EventEmitters were moved to functions: `executeFunction` and `transfer`. Every time you call these functions you get clear events cache.
