### PR TITLE
BUGFIX: missing query params when using api key

### DIFF
--- a/scripts/genWeb3API.js
+++ b/scripts/genWeb3API.js
@@ -108,16 +108,15 @@ static async fetch({ endpoint, params }) {
   try {
     const parameterizedUrl = this.getParameterizedUrl(url, params);
     const body = this.getBody(params, bodyParams);
-    const http = axios.create({
-      baseURL: this.baseURL,
+    const response = await axios(this.baseURL + parameterizedUrl, {
+      params,
+      method,
+      body,
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
         'x-api-key': this.apiKey,
       },
-    });
-    const response = await http[method.toLowerCase()](parameterizedUrl, body, {
-      params,
     });
     return response.data;
   } catch (error) {

--- a/scripts/generateWeb3ApiTypes.js
+++ b/scripts/generateWeb3ApiTypes.js
@@ -105,7 +105,7 @@ ${pathByTag[tag].map(path => makeMethod(pathDetails, path)).join('')}  }
 const makeGeneratedWeb3ApiType = (tags, pathByTag, pathDetails) => {
   let content = `export default class Web3Api {\n`;
 
-  content += `  static initialize: (serverUrl: string) => void;\n`;
+  content += `  static initialize: (options: {apiKey?: string, serverUrl?: string, Moralis?: any}) => void;\n`;
   content += `\n`;
 
   tags.forEach(tag => {

--- a/src/MoralisWeb3Api.js
+++ b/src/MoralisWeb3Api.js
@@ -87,16 +87,15 @@ static async fetch({ endpoint, params }) {
   try {
     const parameterizedUrl = this.getParameterizedUrl(url, params);
     const body = this.getBody(params, bodyParams);
-    const http = axios.create({
-      baseURL: this.baseURL,
+    const response = await axios(this.baseURL + parameterizedUrl, {
+      params,
+      method,
+      body,
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
         'x-api-key': this.apiKey,
       },
-    });
-    const response = await http[method.toLowerCase()](parameterizedUrl, body, {
-      params,
     });
     return response.data;
   } catch (error) {

--- a/types/generated/web3Api.d.ts
+++ b/types/generated/web3Api.d.ts
@@ -1866,7 +1866,7 @@ export interface operations {
 export interface external {}
 
 export default class Web3Api {
-  static initialize: (serverUrl: string) => void;
+  static initialize: (options: {apiKey?: string, serverUrl?: string, Moralis?: any}) => void;
 
   static native: {
     getBlock: (options: operations["getBlock"]["parameters"]["query"] & operations["getBlock"]["parameters"]["path"]) => Promise<operations["getBlock"]["responses"]["200"]["content"]["application/json"]>;


### PR DESCRIPTION
---
Options are not sent to api
---

Passing a chain to the Moralis.Web3Api always sent results for ETH

## New Pull Request

### Checklist

- [X ] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [ X] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [ X] I have made corresponding changes to the documentation
- [ X] I have updated Typescript definitions when needed

### Issue Description

The `axios.create` method of axios does not pass the params in the query string leading to inaccurate results.

### Solution Description

Use the main axios api to ensure the query params are sent along with the request
