### PR TITLE
feature: check if sdk is updated

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -14,10 +14,6 @@ import { run } from './Cloud';
 import detectEthereumProvider from '@metamask/detect-provider';
 import createSigningData from './createSigningData';
 const EventEmitter = require('events');
-const { checkForSdkUpdates } = require('./utils');
-
-// Check if the SDK is updated
-checkForSdkUpdates();
 
 export const EthereumEvents = {
   CONNECT: 'connect',

--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -14,6 +14,10 @@ import { run } from './Cloud';
 import detectEthereumProvider from '@metamask/detect-provider';
 import createSigningData from './createSigningData';
 const EventEmitter = require('events');
+const { checkForSdkUpdates } = require('./utils');
+
+// Check if the SDK is updated
+checkForSdkUpdates();
 
 export const EthereumEvents = {
   CONNECT: 'connect',

--- a/src/Parse.js
+++ b/src/Parse.js
@@ -16,7 +16,7 @@ import InstallationController from './InstallationController';
 import * as ParseOp from './ParseOp';
 import RESTController from './RESTController';
 import MoralisWeb3 from './MoralisWeb3';
-
+const { checkForSdkUpdates } = require('./utils');
 /**
  * Contains all Moralis API classes and functions.
  *
@@ -68,6 +68,9 @@ class Moralis extends MoralisWeb3 {
     if (appId && serverUrl) {
       await this.initPlugins(plugins);
     }
+
+    // Check if SDK is updated
+    await checkForSdkUpdates();
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,14 +1,14 @@
-import axios from 'axios';
 import RESTController from './RESTController';
 
 const DEEP_INDEX_API_HOST = 'deep-index.moralis.io';
 const DEEP_INDEX_SWAGGER_PATH = '/api-docs/v2/swagger.json';
 
 const fetchSwaggerJson = async () => {
-  const http = await axios.create({ baseURL: `https://${DEEP_INDEX_API_HOST}` });
-  const response = await http.get(DEEP_INDEX_SWAGGER_PATH);
-  const result = response.data;
-  return result;
+  const { response } = await RESTController.ajax(
+    'GET',
+    `https://${DEEP_INDEX_API_HOST}${DEEP_INDEX_SWAGGER_PATH}`
+  );
+  return response;
 };
 
 const getPathByTag = swaggerJSON => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,8 +54,24 @@ const fetchEndpoints = async () => {
   return data;
 };
 
+const checkForSdkUpdates = async () => {
+  try {
+    const { data } = await axios.get('https://registry.npmjs.org/-/v1/search?text=moralis&size=1');
+    const latestVersion = data.objects[0].package.version;
+    const installedVersion = process.env.npm_package_version;
+    if (installedVersion < latestVersion)
+      // eslint-disable-next-line no-console
+      console.warn(
+        'You are not using the latest version of the SDK. Please update it as soon as possible to enjoy the newest features.'
+      );
+  } catch (error) {
+    throw new Error('Could not verify SDK version');
+  }
+};
+
 module.exports = {
   fetchSwaggerJson,
   getPathByTag,
   fetchEndpoints,
+  checkForSdkUpdates,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import axios from 'axios';
+const axios = require('axios');
 
 const DEEP_INDEX_API_HOST = 'deep-index.moralis.io';
 const DEEP_INDEX_SWAGGER_PATH = '/api-docs/v2/swagger.json';

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,7 +69,8 @@ const checkForSdkUpdates = async () => {
         'You are not using the latest version of the SDK. Please update it as soon as possible to enjoy the newest features.'
       );
   } catch (error) {
-    throw new Error('Could not verify SDK version');
+    // eslint-disable-next-line no-console
+    console.warn('Could not verify SDK version');
   }
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
-const axios = require('axios');
+import axios from 'axios';
+import RESTController from './RESTController';
 
 const DEEP_INDEX_API_HOST = 'deep-index.moralis.io';
 const DEEP_INDEX_SWAGGER_PATH = '/api-docs/v2/swagger.json';
@@ -56,8 +57,11 @@ const fetchEndpoints = async () => {
 
 const checkForSdkUpdates = async () => {
   try {
-    const { data } = await axios.get('https://registry.npmjs.org/-/v1/search?text=moralis&size=1');
-    const latestVersion = data.objects[0].package.version;
+    const { response } = await RESTController.ajax(
+      'GET',
+      'https://registry.npmjs.org/-/v1/search?text=moralis&size=1'
+    );
+    const latestVersion = response.objects[0].package.version;
     const installedVersion = process.env.npm_package_version;
     if (installedVersion < latestVersion)
       // eslint-disable-next-line no-console


### PR DESCRIPTION
---
name: 'Pull request'
about: Notify the user when the SDK is not updated
---

## New Pull Request

### Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [] I have made corresponding changes to the documentation
- [] I have updated Typescript definitions when needed

### Issue Description
Need a way to notify users when the SDK is not updated.

### Solution Description
Match the version in pkg.json with the one returned by the npm registry.
Could not use a better way because browserify breaks if we import package.json
