### PR TITLE
fix: add missing type declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -235,6 +235,7 @@ export namespace Moralis {
     provider?: Web3ProviderType;
     type?: AuthenticationType;
     chainId?: number;
+    signingMessage?: string;
   }
   type EnableOptions = Pick<AuthenticationOptions, 'provider' | 'chainId'>;
   type LinkOptions = Object.SaveOptions;


### PR DESCRIPTION
---
name: 'Add missing type declaration for signingMessage'
about: missing declaration #135 
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [ ] I have made corresponding changes to the documentation (no corresponding documentation)
- [x] I have updated Typescript definitions when needed

### Issue Description
When trying to update the signingMessage property in the options argument of theMoralis.Web3.authenticate() function, I get the following typescript error:
```
TS2345: Argument of type '{ signingMessage: string; }' is not assignable to parameter of type 'AuthenticationOptions'.
  Object literal may only specify known properties, and 'signingMessage' does not exist in type 'AuthenticationOptions'.
```
This is how my imports are implemented on the vue app in question (based off of the vue3-boilerplate project):

```ts
 const user: UserModel = await $moralis.Web3.authenticate({
     signingMessage: "sign test",
 });
 ```
When I run the above snippet with the $moralis object typed as `any` the code compiles and runs as expected.

Related issue: #`135`

[issue # 135](https://github.com/MoralisWeb3/Moralis-JS-SDK/issues/135)

### Solution Description

Added a type declaration
