### PR TITLE
Add `sol` to `AuthenticationType` (Typescript)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -229,7 +229,7 @@ export namespace Moralis {
   }
 
   type Web3ProviderType = 'metamask' | 'walletconnect' | 'walletConnect' | 'wc';
-  type AuthenticationType = 'evm' | 'dot' | 'polkadot' | 'kusama' | 'erd' | 'elrond';
+  type AuthenticationType = 'evm' | 'dot' | 'polkadot' | 'kusama' | 'erd' | 'elrond' | 'sol';
   type Web3Provider = MoralisWalletConnectProvider | MoralisInjectedProvider;
   interface AuthenticationOptions {
     provider?: Web3ProviderType;


### PR DESCRIPTION
---
name: Missing `sol` type (Moralis Authentication) for Phantom Wallet
about: Add `sol` to `AuthenticationType` (Typescript)
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Phantom Wallet has been added as an Authentication Method in Moralis SDK, but `type: sol` will get error because it is a missing option in `AuthenticationType`, which will prompt typescript type error issue.

Related issue: #`FILL_THIS_OUT`

### Solution Description

Add `sol` to `AuthenticationType` in `types/index.d.ts`.
