### PR TITLE
Fix Custom Web3 Wallet Authentication with Moralis SDK

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -39,15 +39,11 @@ class MoralisWeb3 {
     return this.ensureWeb3IsInstalled();
   }
 
-  static setEnableWeb3(fn) {
-    this.customEnableWeb3 = fn;
-  }
-
   static async enableWeb3(options) {
     let web3;
 
-    if (this.customEnableWeb3) {
-      web3 = await this.customEnableWeb3(options);
+    if (options?.provider === 'customWallet' && options?.customEnableWeb3) {
+      web3 = await options.customEnableWeb3();
     } else {
       if (this.speedyNodeApiKey) {
         options.speedyNodeApiKey = this.speedyNodeApiKey;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -228,7 +228,7 @@ export namespace Moralis {
     static cleanupStaleData: () => void;
   }
 
-  type Web3ProviderType = 'metamask' | 'walletconnect' | 'walletConnect' | 'wc';
+  type Web3ProviderType = 'metamask' | 'walletconnect' | 'walletConnect' | 'wc' | 'customWallet';
   type AuthenticationType = 'evm' | 'dot' | 'polkadot' | 'kusama' | 'erd' | 'elrond' | 'sol';
   type Web3Provider = MoralisWalletConnectProvider | MoralisInjectedProvider;
   interface AuthenticationOptions {
@@ -236,6 +236,7 @@ export namespace Moralis {
     type?: AuthenticationType;
     chainId?: number;
     signingMessage?: string;
+    customEnableWeb3?: () => Promise<NativeWeb3>;
   }
   type EnableOptions = Pick<AuthenticationOptions, 'provider' | 'chainId'>;
   type LinkOptions = Object.SaveOptions;
@@ -394,7 +395,6 @@ export namespace Moralis {
     static enableWeb3: (options?: EnableOptions) => Promise<NativeWeb3>;
     /** @deprecated use enableWeb3 instead */
     static enable: (options?: EnableOptions) => Promise<NativeWeb3>;
-    static setEnableWeb3: (enable: (options?: any) => Promise<NativeWeb3>) => Promise<NativeWeb3>;
     static cleanup: () => Promise<void>;
     static authenticate: (options?: AuthenticationOptions) => Promise<User>;
     static link: (account: string, options?: LinkOptions) => Promise<User>;


### PR DESCRIPTION
---
name: Fix Custom Enable Web3 for Moralis Authentication/Enable Web3
about: Cannot authenticate with Metamask/WalletConnect after setEnableWeb3
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

After `setEnableWeb3` is called to set custom web3 wallet provider, authentication with Metamask/Walletconnect can't be triggered. Instead, it keeps persisting calling the custom web3 wallet.

Related issue: https://github.com/MoralisWeb3/Moralis-JS-SDK/issues/168

### Solution Description

Delete `setEnableWeb3` and add `customEnableWeb3` field as a replacement in the `options` field for `Moralis.authenticate` and `Moralis.enableWeb3`
