### PR TITLE
fix: export for Moralis.Units

### DIFF
--- a/src/UnitConvert.js
+++ b/src/UnitConvert.js
@@ -13,3 +13,5 @@ class UnitConverter {
     return ethers.utils.formatUnits(value, decimals);
   }
 }
+
+module.exports = UnitConverter;


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

`Moralis.Units` is not defined, as the export of UnitConverter has been removed during a merge-conflict.

Related issue: #`FILL_THIS_OUT`

### Solution Description

Exporting `UnitConverter`