### PR TITLE
fix: prevent walletconnect disconnect error

### DIFF
--- a/src/Web3Connector/WalletConnectWeb3Connector.js
+++ b/src/Web3Connector/WalletConnectWeb3Connector.js
@@ -86,7 +86,13 @@ class WalletConnectWeb3Connector extends AbstractWeb3Connector {
     this.account = null;
     this.chainId = null;
 
-    await this.provider.disconnect();
+    if (this.provider) {
+      try {
+        await this.provider.disconnect();
+      } catch {
+        // Do nothing
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Prevent an error where walletconnect provider is not defined yet while
calling disconnect

---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [ ] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #`FILL_THIS_OUT`

### Solution Description

<!-- Add a description of the solution in this PR. -->
