### PR TITLE
fix: prevent loading issue when unpkg is down

### DIFF
--- a/src/Parse.js
+++ b/src/Parse.js
@@ -68,7 +68,7 @@ class Moralis extends MoralisWeb3 {
     }
 
     // Check if SDK is updated
-    await checkForSdkUpdates();
+    checkForSdkUpdates();
   }
 
   /**


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Moralis.start is being stuck if unpk is not responsing

### Solution Description

Remove the await to let the start function being finished without this check