### PR TITLE
fix: avoid duplicate enableWeb3 calls

### DIFF
--- a/src/InternalWeb3Provider.js
+++ b/src/InternalWeb3Provider.js
@@ -21,6 +21,11 @@ export const InternalWeb3Events = Object.freeze({
 class InternalWeb3Provider extends EventEmitter {
   constructor(connector) {
     super();
+
+    if (!connector) {
+      throw new Error('Cannot initialize InternalWeb3Provider without a connector');
+    }
+
     this.connector = connector;
 
     this.handleAccountChanged = this.handleAccountChanged.bind(this);
@@ -30,6 +35,10 @@ class InternalWeb3Provider extends EventEmitter {
   }
 
   async activate(options) {
+    if (!this.connector) {
+      throw new Error('Cannot acticate InternalWeb3Provider without a connector');
+    }
+
     const { provider, chainId, account } = await this.connector.activate(options);
 
     this.provider = provider;

--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -31,6 +31,7 @@ class MoralisWeb3 {
   // Internal web3 provider, containing the Ethers.js Web3 library for internal usage for handling transactions, contracts etc.
   static internalWeb3Provider = null;
   static Plugins = {};
+  static isEnablingWeb3 = false;
 
   static addListener(eventName, listener) {
     MoralisEmitter.on(eventName, listener);
@@ -76,68 +77,82 @@ class MoralisWeb3 {
   }
 
   static async enableWeb3(options) {
-    if (this.speedyNodeApiKey) {
-      options.speedyNodeApiKey = this.speedyNodeApiKey;
-      options.provider = 'network';
+    if (this.isEnablingWeb3) {
+      throw new Error(
+        'Cannot execute Moralis.enableWeb3(), as Moralis Moralis.enableWeb3() already has been called, but is not finished yet '
+      );
     }
-
-    if (this.internalWeb3Provider) {
-      await this.cleanup();
-    }
-
-    const Connector = options?.connector ?? MoralisWeb3.getWeb3Connector(options?.provider);
-    const connector = new Connector(options);
-
-    this.internalWeb3Provider = new InternalWeb3Provider(connector);
-
-    this.internalWeb3Provider.on(InternalWeb3Events.ACCOUNT_CHANGED, args =>
-      this.handleWeb3AccountChanged(args)
-    );
-    this.internalWeb3Provider.on(InternalWeb3Events.CHAIN_CHANGED, args =>
-      this.handleWeb3ChainChanged(args)
-    );
-    this.internalWeb3Provider.on(InternalWeb3Events.PROVIDER_CONNECT, args =>
-      this.handleWeb3Connect(args)
-    );
-    this.internalWeb3Provider.on(InternalWeb3Events.PROVIDER_DISCONNECT, args =>
-      this.handleWeb3Disconnect(args)
-    );
-
-    let provider;
-    let chainId;
-    let account;
-    let internalWeb3;
-
     try {
-      ({
-        provider,
+      this.isEnablingWeb3 = true;
+
+      if (this.speedyNodeApiKey) {
+        options.speedyNodeApiKey = this.speedyNodeApiKey;
+        options.provider = 'network';
+      }
+
+      if (this.internalWeb3Provider) {
+        await this.cleanup();
+      }
+
+      const Connector = options?.connector ?? MoralisWeb3.getWeb3Connector(options?.provider);
+      const connector = new Connector(options);
+
+      this.internalWeb3Provider = new InternalWeb3Provider(connector);
+
+      this.internalWeb3Provider.on(InternalWeb3Events.ACCOUNT_CHANGED, args =>
+        this.handleWeb3AccountChanged(args)
+      );
+      this.internalWeb3Provider.on(InternalWeb3Events.CHAIN_CHANGED, args =>
+        this.handleWeb3ChainChanged(args)
+      );
+      this.internalWeb3Provider.on(InternalWeb3Events.PROVIDER_CONNECT, args =>
+        this.handleWeb3Connect(args)
+      );
+      this.internalWeb3Provider.on(InternalWeb3Events.PROVIDER_DISCONNECT, args =>
+        this.handleWeb3Disconnect(args)
+      );
+
+      let provider;
+      let chainId;
+      let account;
+      let internalWeb3;
+
+      try {
+        ({
+          provider,
+          chainId,
+          account,
+          web3: internalWeb3,
+        } = await this.internalWeb3Provider.activate(options));
+
+        if (!provider) {
+          throw new Error('Failed to activate, no provider returned');
+        }
+      } catch (error) {
+        await this.cleanup();
+        throw error;
+      }
+
+      let web3 = null;
+
+      web3 = new ethers.providers.Web3Provider(provider);
+
+      this.web3 = web3;
+      MoralisEmitter.emit(InternalWeb3Events.WEB3_ENABLED, {
         chainId,
         account,
-        web3: internalWeb3,
-      } = await this.internalWeb3Provider.activate(options));
+        connector,
+        provider,
+        web3,
+      });
 
-      if (!provider) {
-        throw new Error('Failed to activate, no provider returned');
-      }
+      return web3;
+      // eslint-disable-next-line no-useless-catch
     } catch (error) {
-      await this.cleanup();
       throw error;
+    } finally {
+      this.isEnablingWeb3 = false;
     }
-
-    let web3 = null;
-
-    web3 = new ethers.providers.Web3Provider(provider);
-
-    this.web3 = web3;
-    MoralisEmitter.emit(InternalWeb3Events.WEB3_ENABLED, {
-      chainId,
-      account,
-      connector,
-      provider,
-      web3,
-    });
-
-    return web3;
   }
 
   static isDotAuth(options) {


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Moralis.enableWeb3 could be called multiple times after eachother. This results in cleaning up the provider, and creating one at the same time. And results in an invalid state of Moralis, where the InternalWeb3Connector has no connector.

Related issue: #`FILL_THIS_OUT`

### Solution Description

Add a boolean, to check when Moralis.enableWeb3 is in process, and throw an error if a user calls enableWeb3 again before the previous call is finished