### PR TITLE
Enable passing argument to `resolveAddress`

### DIFF
--- a/types/generated/web3Api.d.ts
+++ b/types/generated/web3Api.d.ts
@@ -2558,7 +2558,7 @@ export default class Web3Api {
 
   static resolve: {
     resolveDomain: (options: operations["resolveDomain"]["parameters"]["query"] & operations["resolveDomain"]["parameters"]["path"]) => Promise<operations["resolveDomain"]["responses"]["200"]["content"]["application/json"]>;
-    resolveAddress: () => Promise<operations["resolveAddress"]["responses"]["200"]["content"]["application/json"]>;
+    resolveAddress: (options: operations["resolveAddress"]["parameters"]["path"]) => Promise<operations["resolveAddress"]["responses"]["200"]["content"]["application/json"]>;
   }
 
   static defi: {


### PR DESCRIPTION
- Fix type signature for `resolver:resolveAddress` method on the
  `Web3Api` class such that it can take in its intended options

---
name: Enable passing argument to `resolveAddress`
about: Reverse Resolution from Eth address to ENS names
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [ ] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated Typescript definitions when needed

### Issue Description

As a user, I was attempting to use the `resolve/:address/reverse` API via the `Web3Api > resolve > resolveAddress` method in my typescript project, and it was not working. The type signature doesn't allow me to pass in options to this method with the address string, so I am unable to use this method.


Related issue: I have not filed an issue related to this, as the solution seems very straightforward. Please let me know if there's anything I can do to make the reviewer's life easier!


### Solution Description

The solution is very simple--just a one-line adjustment to the type signature for this method. Very small and straight forward, and I don't believe any other adjustments need to be made.

