### PR TITLE
fix: preserve sessions for walletconnect and magic

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -92,10 +92,6 @@ class MoralisWeb3 {
         options.provider = 'network';
       }
 
-      if (this.internalWeb3Provider) {
-        await this.cleanup();
-      }
-
       const Connector = options?.connector ?? MoralisWeb3.getWeb3Connector(options?.provider);
       const connector = new Connector(options);
 
@@ -202,6 +198,9 @@ class MoralisWeb3 {
     return this.cleanup();
   }
 
+  /**
+   * Cleanup previously established provider
+   */
   static async cleanup() {
     if (this.web3 && this.internalWeb3Provider) {
       MoralisEmitter.emit(InternalWeb3Events.WEB3_DEACTIVATED, {
@@ -228,7 +227,13 @@ class MoralisWeb3 {
         this.handleWeb3Disconnect
       );
 
-      await this.internalWeb3Provider.deactivate();
+      // WIP: deactivate ALL connections??
+      // For example, if walletconnect has been enabled, then later on metamask, then wc is not the internalProvider, but still has an active connection
+      try {
+        await this.internalWeb3Provider.deactivate();
+      } catch (error) {
+        // Do nothing
+      }
     }
 
     this.internalWeb3Provider = null;

--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -227,7 +227,6 @@ class MoralisWeb3 {
         this.handleWeb3Disconnect
       );
 
-      // WIP: deactivate ALL connections??
       // For example, if walletconnect has been enabled, then later on metamask, then wc is not the internalProvider, but still has an active connection
       try {
         await this.internalWeb3Provider.deactivate();

--- a/src/Web3Connector/MagicWeb3Connector.js
+++ b/src/Web3Connector/MagicWeb3Connector.js
@@ -4,15 +4,9 @@ import AbstractWeb3Connector from './AbstractWeb3Connector';
 
 export default class MagicWeb3Connector extends AbstractWeb3Connector {
   type = 'MagicLink';
-  async activate({ email, apiKey, network }) {
+  async activate({ email, apiKey, network } = {}) {
     let magic = null;
     let ether = null;
-
-    try {
-      await this.deactivate();
-    } catch (error) {
-      // Do nothing
-    }
 
     if (!email) {
       throw new Error('"email" not provided, please provide Email');
@@ -79,5 +73,6 @@ export default class MagicWeb3Connector extends AbstractWeb3Connector {
     }
     this.account = null;
     this.chainId = null;
+    this.provider = null;
   };
 }


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Refreshing the page will reset walletconnect session


### Solution Description

Don't clear the session, and make it optional by calling a cleanup function. Also removed the `deactivate` function call upon calling enableWeb3.
Now the behaviour is more consistent across the connectors and the user can deactivate by calling the `deactivate` manually or closing the session in the respective wallet-app