### PR TITLE
fix: cleanup web3 on logout

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -1139,7 +1139,9 @@ const DefaultController = {
   },
 
   logOut(options: RequestOptions): Promise<ParseUser> {
-    MoralisWeb3.cleanup();
+    const Moralis = require('./Parse');
+
+    Moralis.cleanup();
     const RESTController = CoreManager.getRESTController();
     if (options.sessionToken) {
       return RESTController.request('POST', 'logout', {}, options);

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -31,6 +31,9 @@ jest.dontMock('../UniqueInstanceStateController');
 jest.dontMock('crypto-js/aes');
 jest.dontMock('crypto-js/enc-utf8');
 jest.setMock('ethers', () => {});
+jest.mock('../Parse.js', () => ({
+  cleanup: () => {},
+}));
 
 jest.mock('uuid', () => {
   let value = 0;


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Web3 does not gets cleaned up on logout, as the reference to MoralisWeb3 is different than Moralis


### Solution Description

Call cleanup on the Moralis class instance