### PR TITLE
fix: expose setting of 'any' network on  provider

### DIFF
--- a/src/InternalWeb3Provider.js
+++ b/src/InternalWeb3Provider.js
@@ -19,7 +19,7 @@ export const InternalWeb3Events = Object.freeze({
  * Gives access to ethers functionalities, initialized by the connector
  */
 class InternalWeb3Provider extends EventEmitter {
-  constructor(connector) {
+  constructor(connector, anyNetwork = false) {
     super();
 
     if (!connector) {
@@ -27,6 +27,7 @@ class InternalWeb3Provider extends EventEmitter {
     }
 
     this.connector = connector;
+    this.anyNetwork = anyNetwork;
 
     this.handleAccountChanged = this.handleAccountChanged.bind(this);
     this.handleChainChanged = this.handleChainChanged.bind(this);
@@ -44,7 +45,9 @@ class InternalWeb3Provider extends EventEmitter {
     this.provider = provider;
     this.chainId = chainId;
     this.account = account;
-    this.web3 = new ethers.providers.Web3Provider(provider, fromHexToDecimal(chainId));
+
+    const network = this.anyNetwork ? 'any' : fromHexToDecimal(chainId);
+    this.web3 = new ethers.providers.Web3Provider(provider, network);
 
     if (this.connector.on) {
       this.connector.on(ConnectorEvents.ACCOUNT_CHANGED, this.handleAccountChanged);

--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -84,6 +84,7 @@ class MoralisWeb3 {
         'Cannot execute Moralis.enableWeb3(), as Moralis Moralis.enableWeb3() already has been called, but is not finished yet '
       );
     }
+
     try {
       this.isEnablingWeb3 = true;
 
@@ -99,7 +100,9 @@ class MoralisWeb3 {
       const Connector = options?.connector ?? MoralisWeb3.getWeb3Connector(options?.provider);
       const connector = new Connector(options);
 
-      this.internalWeb3Provider = new InternalWeb3Provider(connector);
+      const anyNetwork = options?.anyNetwork === true ? true : false;
+
+      this.internalWeb3Provider = new InternalWeb3Provider(connector, anyNetwork);
 
       this.internalWeb3Provider.on(InternalWeb3Events.ACCOUNT_CHANGED, args =>
         this.handleWeb3AccountChanged(args)


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

EthersJs throws an error if the backend chain changes (for example Metamask)

### Solution Description

Allow the setting 'any' network ( as described in https://github.com/ethers-io/ethers.js/issues/866) via the `anyNetwork` option when calling `authenticate` or `enableWeb3`
