### PR TITLE
fix: account for metamask disconnect issue

### DIFF
--- a/src/MoralisWeb3.js
+++ b/src/MoralisWeb3.js
@@ -65,7 +65,7 @@ class MoralisWeb3 {
   }
 
   static handleWeb3ChainChanged(chainId) {
-    this.web3 = this.internalWeb3Provider.web3;
+    this.web3 = this.internalWeb3Provider?.web3;
     MoralisEmitter.emit(InternalWeb3Events.CHAIN_CHANGED, chainId);
   }
 
@@ -74,6 +74,9 @@ class MoralisWeb3 {
   }
 
   static handleWeb3Disconnect(error) {
+    if (error?.message === 'MetaMask: Disconnected from chain. Attempting to connect.') {
+      return;
+    }
     this.cleanup();
     MoralisEmitter.emit(InternalWeb3Events.PROVIDER_DISCONNECT, error);
   }


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Metamask might disconnect when switching to a chain (example some Binance Testnet rpcs). In this case, metamask will automatically try to reconnect

Related issue: #`FILL_THIS_OUT`

### Solution Description

Do not call `cleanup` if metamask disconnects with the message that it will try to reconnect. Let metamask try to reconnect instead.