### PR TITLE
fix: newsession param for walletconnect and magic

### DIFF
--- a/src/Web3Connector/MagicWeb3Connector.js
+++ b/src/Web3Connector/MagicWeb3Connector.js
@@ -4,7 +4,7 @@ import AbstractWeb3Connector from './AbstractWeb3Connector';
 
 export default class MagicWeb3Connector extends AbstractWeb3Connector {
   type = 'MagicLink';
-  async activate({ email, apiKey, network } = {}) {
+  async activate({ email, apiKey, network, newSession } = {}) {
     let magic = null;
     let ether = null;
 
@@ -37,6 +37,17 @@ export default class MagicWeb3Connector extends AbstractWeb3Connector {
       magic = new Magic(apiKey, {
         network: network,
       });
+
+      if (newSession) {
+        if (magic?.user) {
+          try {
+            await magic?.user?.logout();
+          } catch (error) {
+            // Do nothing
+          }
+        }
+      }
+
       ether = new ethers.providers.Web3Provider(magic.rpcProvider);
       await magic.auth.loginWithMagicLink({
         email: email,

--- a/src/Web3Connector/WalletConnectWeb3Connector.js
+++ b/src/Web3Connector/WalletConnectWeb3Connector.js
@@ -20,6 +20,11 @@ class WalletConnectWeb3Connector extends AbstractWeb3Connector {
   type = 'WalletConnect';
 
   async activate({ chainId: providedChainId, mobileLinks, newSession } = {}) {
+    // Log out of any previous sessions
+    if (newSession) {
+      this.cleanup();
+    }
+
     if (!this.provider) {
       let WalletConnectProvider;
       const config = {


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

Now that sessions are preserved between connections, we need a way for the user to indicate if they want to force a new session.
Ex. When they want to force the user to scan a new qr code via WalletConnect

### Solution Description

Add a `newSession` prop for walletconnect and magic, to allow this behaviour.