### PR TITLE
update log message if running on node.js

### DIFF
--- a/src/Parse.js
+++ b/src/Parse.js
@@ -138,7 +138,7 @@ class Moralis extends MoralisWeb3 {
       /* eslint-disable no-console */
       console.log(
         "It looks like you're using the browser version of the SDK in a " +
-          "node.js environment. You should require('parse/node') instead."
+          "node.js environment. You should require('moralis/node') instead."
       );
       /* eslint-enable no-console */
     }

--- a/src/__tests__/browser-test.js
+++ b/src/__tests__/browser-test.js
@@ -32,13 +32,13 @@ describe('Browser', () => {
     process.env.PARSE_BUILD = 'node';
   });
 
-  it('warning initializing parse/node in browser', () => {
+  it('warning initializing moralis/node in browser', () => {
     const Parse = require('../Parse');
     jest.spyOn(console, 'log').mockImplementationOnce(() => {});
     jest.spyOn(Parse, '_initialize').mockImplementationOnce(() => {});
     Parse.initialize('A', 'B');
     expect(console.log).toHaveBeenCalledWith(
-      "It looks like you're using the browser version of the SDK in a node.js environment. You should require('parse/node') instead."
+      "It looks like you're using the browser version of the SDK in a node.js environment. You should require('moralis/node') instead."
     );
     expect(Parse._initialize).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
If using require('moralis') on node.js, the error message should provide the correct require command.  Updated to use moralis module (previously parse)

---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x ] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [ x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [ x] I have made corresponding changes to the documentation
- [ x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->
The log message if the wrong version of the Moralis module is used with nodej.js provides the incorrect solution

Related issue: #`FILL_THIS_OUT`

### Solution Description

<!-- Add a description of the solution in this PR. -->
Updated the log message to include the correct require command.