### PR TITLE
Add missing ipfs() and hash() methods to Moralis.File type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -675,6 +675,8 @@ export namespace Moralis {
      */
     getData(): Promise<string>;
     url(options?: { forceSecure?: boolean }): string;
+    ipfs(): string;
+    hash(): string;
     metadata(): Record<string, any>;
     tags(): Record<string, any>;
     name(): string;


### PR DESCRIPTION
Fix #345

---
name: 'Fix Moralis.File type'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #345 

### Solution Description

<!-- Add a description of the solution in this PR. -->
Add the methods to the definition.