### PR TITLE
Test/evm api resolve address

### DIFF
--- a/packages/integration/mockRequests/config.ts
+++ b/packages/integration/mockRequests/config.ts
@@ -1,2 +1,2 @@
-export const MOCK_API_KEY = 'test-api-key';
+export const MOCK_API_KEY = 'xfPASvc8aCpawLIB4ICLrrmKA2pZO6TvUnKIh3n4I4PSkRuC1Q8VCqu6tobkyELv';
 export const EVM_API_ROOT = 'https://deep-index.moralis.io/api/v2';

--- a/packages/integration/mockRequests/config.ts
+++ b/packages/integration/mockRequests/config.ts
@@ -1,2 +1,2 @@
-export const MOCK_API_KEY = 'xfPASvc8aCpawLIB4ICLrrmKA2pZO6TvUnKIh3n4I4PSkRuC1Q8VCqu6tobkyELv';
+export const MOCK_API_KEY = 'test-api-key';
 export const EVM_API_ROOT = 'https://deep-index.moralis.io/api/v2';

--- a/packages/integration/mockRequests/evmApi/resolveAddress.ts
+++ b/packages/integration/mockRequests/evmApi/resolveAddress.ts
@@ -1,0 +1,28 @@
+import { rest } from 'msw';
+import { EVM_API_ROOT, MOCK_API_KEY } from '../config';
+
+export const mockResolveAddresses: Record<string, string> = {
+  '0xd8da6bf26964af9d7eed9e03e53415d37aa96045': 'vitalik.eth',
+};
+
+export const mockResolveAddress = rest.get(`${EVM_API_ROOT}/resolve/:address`, (req, res, ctx) => {
+  const address = req.params.address as string;
+  const apiKey = req.headers.get('x-api-key');
+
+  if (apiKey !== MOCK_API_KEY) {
+    return res(ctx.status(401));
+  }
+
+  const value = mockResolveAddresses[address];
+
+  if (!value) {
+    return res(ctx.status(404));
+  }
+
+  return res(
+    ctx.status(200),
+    ctx.json({
+      name: value,
+    }),
+  );
+});

--- a/packages/integration/mockRequests/mockRequests.ts
+++ b/packages/integration/mockRequests/mockRequests.ts
@@ -1,6 +1,7 @@
 import { setupServer } from 'msw/node';
 import { mockResolveDomain } from './evmApi/resolveDomain';
+import { mockResolveAddress } from './evmApi/resolveAddress';
 
-const handlers = [mockResolveDomain];
+const handlers = [mockResolveDomain, mockResolveAddress];
 
 export const mockServer = setupServer(...handlers);

--- a/packages/integration/test/evmApi/resolveAddress.test.ts
+++ b/packages/integration/test/evmApi/resolveAddress.test.ts
@@ -1,0 +1,50 @@
+import Core from '@moralis/core';
+import EvmApi from '@moralis/evm-api';
+import { MOCK_API_KEY } from '../../mockRequests/config';
+import { mockServer } from '../../mockRequests/mockRequests';
+
+describe('Moralis EvmApi', () => {
+  const server = mockServer;
+
+  beforeAll(() => {
+    Core.registerModules([EvmApi]);
+    Core.start({
+      apiKey: MOCK_API_KEY,
+    });
+
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should resolve an address and return a name', async () => {
+    const result = await EvmApi.resolve.resolveAddress({
+      address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+    });
+
+    expect(result.toJSON().name).toBe('vitalik.eth'.toLowerCase());
+    expect(result.legacy.name).toBe('vitalik.eth');
+    expect(result.result.name).toBe('vitalik.eth');
+  });
+
+  it('should not resolve an address and return an error code', () => {
+    const failedResult = EvmApi.resolve
+      .resolveAddress({
+        address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604',
+      })
+      .then()
+      .catch((err) => {
+        console.log('error ==>', err);
+        return err;
+      });
+
+    expect(failedResult).toBeDefined();
+    expect(
+      EvmApi.resolve.resolveAddress({
+        address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604',
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"[C0005] Invalid address provided"`);
+  });
+});


### PR DESCRIPTION
---
name: Fetch and transform resolve.resolveAddress
about: Resolves an address and get the name.
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: issue [#158]

### Solution Description
Users can fetch an address, resolve the address and get a name.

<!-- Add a description of the solution in this PR. -->
