### PR TITLE
Test/evm api get pair address

### DIFF
--- a/packages/integration/mockRequests/config.ts
+++ b/packages/integration/mockRequests/config.ts
@@ -1,2 +1,2 @@
-export const MOCK_API_KEY = 'test-api-key';
+export const MOCK_API_KEY = 'xfPASvc8aCpawLIB4ICLrrmKA2pZO6TvUnKIh3n4I4PSkRuC1Q8VCqu6tobkyELv';
 export const EVM_API_ROOT = 'https://deep-index.moralis.io/api/v2';

--- a/packages/integration/mockRequests/config.ts
+++ b/packages/integration/mockRequests/config.ts
@@ -1,2 +1,2 @@
-export const MOCK_API_KEY = 'xfPASvc8aCpawLIB4ICLrrmKA2pZO6TvUnKIh3n4I4PSkRuC1Q8VCqu6tobkyELv';
+export const MOCK_API_KEY = 'test-api-key';
 export const EVM_API_ROOT = 'https://deep-index.moralis.io/api/v2';

--- a/packages/integration/mockRequests/evmApi/getPairAddress.ts
+++ b/packages/integration/mockRequests/evmApi/getPairAddress.ts
@@ -1,0 +1,31 @@
+import { rest } from 'msw';
+import { EVM_API_ROOT, MOCK_API_KEY } from '../config';
+
+export const mockGetPairAddresses: Record<string, string> = {
+  '0xa2107fa5b38d9bbd2c461d6edf11b11a50f6b974': '233668669478185909225031',
+};
+
+export const mockGetPairAddress = rest.get(`${EVM_API_ROOT}/:pair_address`, (req, res, ctx) => {
+  const pair_address = req.params.pair_address as string;
+  const apiKey = req.headers.get('x-api-key');
+
+  if (apiKey !== MOCK_API_KEY) {
+    return res(ctx.status(401));
+  }
+
+  const value1 = mockGetPairAddresses[pair_address];
+
+  //console.log('reserves ==>', value1);
+
+  if (!value1) {
+    return res(ctx.status(404));
+  }
+
+  return res(
+    ctx.status(200),
+    ctx.json({
+      reserve0: value1,
+      reserve1: value1,
+    }),
+  );
+});

--- a/packages/integration/mockRequests/evmApi/resolveAddress.ts
+++ b/packages/integration/mockRequests/evmApi/resolveAddress.ts
@@ -1,0 +1,28 @@
+import { rest } from 'msw';
+import { EVM_API_ROOT, MOCK_API_KEY } from '../config';
+
+export const mockResolveAddresses: Record<string, string> = {
+  '0xd8da6bf26964af9d7eed9e03e53415d37aa96045': 'vitalik.eth',
+};
+
+export const mockResolveAddress = rest.get(`${EVM_API_ROOT}/resolve/:address`, (req, res, ctx) => {
+  const address = req.params.address as string;
+  const apiKey = req.headers.get('x-api-key');
+
+  if (apiKey !== MOCK_API_KEY) {
+    return res(ctx.status(401));
+  }
+
+  const value = mockResolveAddresses[address];
+
+  if (!value) {
+    return res(ctx.status(404));
+  }
+
+  return res(
+    ctx.status(200),
+    ctx.json({
+      name: value,
+    }),
+  );
+});

--- a/packages/integration/mockRequests/mockRequests.ts
+++ b/packages/integration/mockRequests/mockRequests.ts
@@ -1,7 +1,8 @@
 import { setupServer } from 'msw/node';
 import { mockResolveDomain } from './evmApi/resolveDomain';
 import { mockResolveAddress } from './evmApi/resolveAddress';
+import { mockGetPairAddress } from './evmApi/getPairAddress';
 
-const handlers = [mockResolveDomain, mockResolveAddress];
+const handlers = [mockResolveDomain, mockResolveAddress, mockGetPairAddress];
 
 export const mockServer = setupServer(...handlers);

--- a/packages/integration/mockRequests/mockRequests.ts
+++ b/packages/integration/mockRequests/mockRequests.ts
@@ -1,6 +1,7 @@
 import { setupServer } from 'msw/node';
 import { mockResolveDomain } from './evmApi/resolveDomain';
+import { mockResolveAddress } from './evmApi/resolveAddress';
 
-const handlers = [mockResolveDomain];
+const handlers = [mockResolveDomain, mockResolveAddress];
 
 export const mockServer = setupServer(...handlers);

--- a/packages/integration/test/evmApi/getPairAddress.test.ts
+++ b/packages/integration/test/evmApi/getPairAddress.test.ts
@@ -1,0 +1,52 @@
+import Core from '@moralis/core';
+import EvmApi from '@moralis/evm-api';
+import { MOCK_API_KEY } from '../../mockRequests/config';
+import { mockServer } from '../../mockRequests/mockRequests';
+
+describe('Moralis EvmApi', () => {
+  const server = mockServer;
+
+  beforeAll(() => {
+    Core.registerModules([EvmApi]);
+    Core.start({
+      apiKey: MOCK_API_KEY,
+    });
+
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should get the liquidity reserves for a given pair address ', async () => {
+    const result = await EvmApi.defi.getPairReserves({
+      pair_address: '0xa2107fa5b38d9bbd2c461d6edf11b11a50f6b974',
+    });
+
+    expect(result.toJSON().reserve0).toBe('230919083588823304348382');
+    expect(result.toJSON().reserve1).toBe('836367848974112604968');
+    expect(result.legacy.reserve0).toBe('230919083588823304348382');
+    expect(result.legacy.reserve1).toBe('836367848974112604968');
+    expect(result.result.reserve0).toBe('230919083588823304348382');
+    expect(result.result.reserve1).toBe('836367848974112604968');
+  });
+
+  it('should not get the liquidity reserves for a given pair address ', async () => {
+    const failedResult = await EvmApi.defi
+      .getPairReserves({
+        pair_address: '0xa2107fa5b38d9bbd2c461d6edf11b11a50f6b974',
+      })
+      .then()
+      .catch((err) => {
+        return err;
+      });
+
+    expect(failedResult).toBeDefined();
+    expect(
+      EvmApi.resolve.resolveAddress({
+        address: '0xa2107fa5b38d9bbd2c461d6edf11b11a50f6b974',
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"[C0006] Request failed with status 400"`);
+  });
+});

--- a/packages/integration/test/evmApi/resolveAddress.test.ts
+++ b/packages/integration/test/evmApi/resolveAddress.test.ts
@@ -1,0 +1,50 @@
+import Core from '@moralis/core';
+import EvmApi from '@moralis/evm-api';
+import { MOCK_API_KEY } from '../../mockRequests/config';
+import { mockServer } from '../../mockRequests/mockRequests';
+
+describe('Moralis EvmApi', () => {
+  const server = mockServer;
+
+  beforeAll(() => {
+    Core.registerModules([EvmApi]);
+    Core.start({
+      apiKey: MOCK_API_KEY,
+    });
+
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should resolve an address and return a name', async () => {
+    const result = await EvmApi.resolve.resolveAddress({
+      address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+    });
+
+    expect(result.toJSON().name).toBe('vitalik.eth'.toLowerCase());
+    expect(result.legacy.name).toBe('vitalik.eth');
+    expect(result.result.name).toBe('vitalik.eth');
+  });
+
+  it('should not resolve an address and return an error code', () => {
+    const failedResult = EvmApi.resolve
+      .resolveAddress({
+        address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604',
+      })
+      .then()
+      .catch((err) => {
+        console.log('error ==>', err);
+        return err;
+      });
+
+    expect(failedResult).toBeDefined();
+    expect(
+      EvmApi.resolve.resolveAddress({
+        address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604',
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"[C0005] Invalid address provided"`);
+  });
+});


### PR DESCRIPTION
---
name: Fetch and transform defi.getPairReserves
about: Test to fetch an address and transform the pair
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: issue [#147]

### Solution Description
A user can get the liquidity reserves for a given pair address

<!-- Add a description of the solution in this PR. -->
