### PR TITLE
test(evmApi) test to get balance of a native account

### DIFF
--- a/packages/integration/mockRequests/evmApi/getNativeBalance.ts
+++ b/packages/integration/mockRequests/evmApi/getNativeBalance.ts
@@ -1,0 +1,28 @@
+import { rest } from 'msw';
+import { EVM_API_ROOT, MOCK_API_KEY } from '../config';
+
+export const mockGetNativeBalances: Record<string, string> = {
+  address: '0x7dE3085b3190B3a787822Ee16F23be010f5F8686',
+};
+
+export const mockGetNativeBalance = rest.get(`${EVM_API_ROOT}/account/:address`, (req, res, ctx) => {
+  const address = req.params.address as string;
+  const apiKey = req.headers.get('x-api-key');
+
+  if (apiKey !== MOCK_API_KEY) {
+    return res(ctx.status(401));
+  }
+
+  const value = mockGetNativeBalances[address];
+
+  if (!value) {
+    return res(ctx.status(404));
+  }
+
+  return res(
+    ctx.status(200),
+    ctx.json({
+      address: value,
+    }),
+  );
+});

--- a/packages/integration/mockRequests/mockRequests.ts
+++ b/packages/integration/mockRequests/mockRequests.ts
@@ -1,7 +1,8 @@
 import { setupServer } from 'msw/node';
 import { mockResolveDomain } from './evmApi/resolveDomain';
 import { mockResolveAddress } from './evmApi/resolveAddress';
+import { mockGetNativeBalance } from './evmApi/getNativeBalance';
 
-const handlers = [mockResolveDomain, mockResolveAddress];
+const handlers = [mockResolveDomain, mockResolveAddress, mockGetNativeBalance];
 
 export const mockServer = setupServer(...handlers);

--- a/packages/integration/test/evmApi/getNativeBalance.test.ts
+++ b/packages/integration/test/evmApi/getNativeBalance.test.ts
@@ -1,0 +1,48 @@
+import Core from '@moralis/core';
+import EvmApi from '@moralis/evm-api';
+import { MOCK_API_KEY } from '../../mockRequests/config';
+import { mockServer } from '../../mockRequests/mockRequests';
+
+describe('Moralis EvmApi', () => {
+  const server = mockServer;
+
+  beforeAll(() => {
+    Core.registerModules([EvmApi]);
+    Core.start({
+      apiKey: MOCK_API_KEY,
+    });
+
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should get the native balance of an account', async () => {
+    const result = await EvmApi.account.getNativeBalance({
+      address: '0x7dE3085b3190B3a787822Ee16F23be010f5F8686',
+    });
+
+    expect(result.toJSON().balance).toBe('39600000000000000');
+    expect(result).toBeDefined();
+  });
+
+  it('should not get the native account balance and return an error code for an invalid address', () => {
+    const failedResult = EvmApi.account
+      .getNativeBalance({
+        address: '0x7dE3085b3190B3a787822Ee16F23be010f5F8686',
+      })
+      .then()
+      .catch((err) => {
+        return err;
+      });
+
+    expect(failedResult).toBeDefined();
+    expect(
+      EvmApi.account.getNativeBalance({
+        address: '0x7dE3085b3190B3a787822Ee16F23be010f5F868',
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"[C0005] Invalid address provided"`);
+  });
+});


### PR DESCRIPTION
---
name: Fetch and transform account.getNativeBalance
about: Test to get the balance of a native account.
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #137

### Solution Description
User can get the balance of a native account by passing the account address.

<!-- Add a description of the solution in this PR. -->
