### PR TITLE
Test/evm api get nft transfers by block

### DIFF
--- a/packages/integration/mockRequests/evmApi/getNFTTransfersByBlock.ts
+++ b/packages/integration/mockRequests/evmApi/getNFTTransfersByBlock.ts
@@ -1,0 +1,31 @@
+import { rest } from 'msw';
+import { EVM_API_ROOT, MOCK_API_KEY } from '../config';
+
+export const mockGetNFTTransfersByBlocks: Record<string, number> = {
+  '0x9b559aef7ea858608c2e554246fe4a24287e7aeeb976848df2b9a2531f4b9171': 3,
+};
+
+export const mockGetNFTTransfersByBlock = rest.get(
+  `${EVM_API_ROOT}/block/:blockNumberOrHash/nft/transfers`,
+  (req, res, ctx) => {
+    const blockNumberOrHash = req.params.blockNumberOrHash as string;
+    const apiKey = req.headers.get('x-api-key');
+
+    if (apiKey !== MOCK_API_KEY) {
+      return res(ctx.status(401));
+    }
+
+    const value = mockGetNFTTransfersByBlocks[blockNumberOrHash];
+
+    if (!value) {
+      return res(ctx.status(404));
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        total: value,
+      }),
+    );
+  },
+);

--- a/packages/integration/mockRequests/mockRequests.ts
+++ b/packages/integration/mockRequests/mockRequests.ts
@@ -9,6 +9,7 @@ import { mockGetTokenTransfer } from './evmApi/getTokenTransfers';
 import { mockGetTransactions } from './evmApi/getTransactions';
 import { mockGetTokenPrice } from './evmApi/getTokenPrice';
 import { mockGetNFTTrades } from './evmApi/getNFTTrades';
+import { mockGetNFTTransfersByBlock } from './evmApi/getNFTTransfersByBlock';
 
 const handlers = [
   mockResolveDomain,
@@ -21,6 +22,7 @@ const handlers = [
   mockGetTransactions,
   mockGetNFTsForContract,
   mockGetNFTTrades,
+  mockGetNFTTransfersByBlock,
 ];
 
 export const mockServer = setupServer(...handlers);

--- a/packages/integration/test/evmApi/getNFTTransfersByBlock.test.ts
+++ b/packages/integration/test/evmApi/getNFTTransfersByBlock.test.ts
@@ -46,6 +46,11 @@ describe('Moralis EvmApi', () => {
       EvmApi.native.getNFTTransfersByBlock({
         blockNumberOrHash: '0x9b559aef7ea858608c2e554246fe4a24287e7aeeb976848df2b9a2531f4b917',
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"[C0005] Invalid address provided"`);
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"[C0005] Invalid block number provided"`);
+    expect(
+      EvmApi.native.getNFTTransfersByBlock({
+        blockNumberOrHash: '',
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"[C0006] Request failed with status 404"`);
   });
 });

--- a/packages/integration/test/evmApi/getNFTTransfersByBlock.test.ts
+++ b/packages/integration/test/evmApi/getNFTTransfersByBlock.test.ts
@@ -1,0 +1,51 @@
+import Core from '@moralisweb3/core';
+import EvmApi from '@moralisweb3/evm-api';
+import { MOCK_API_KEY } from '../../mockRequests/config';
+import { mockServer } from '../../mockRequests/mockRequests';
+
+describe('Moralis EvmApi', () => {
+  const server = mockServer;
+
+  beforeAll(() => {
+    Core.registerModules([EvmApi]);
+    Core.start({
+      apiKey: MOCK_API_KEY,
+    });
+
+    server.listen({
+      onUnhandledRequest: 'warn',
+    });
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should get the NFT transfers by block of a hash', async () => {
+    const result = await EvmApi.native.getNFTTransfersByBlock({
+      blockNumberOrHash: '0x9b559aef7ea858608c2e554246fe4a24287e7aeeb976848df2b9a2531f4b9171',
+    });
+
+    expect(result).toBeDefined();
+    expect(result.legacy.total).toBe(3);
+    expect(result).toEqual(expect.objectContaining({}));
+  });
+
+  it('should not get the NFT transfers by block of an invalid block number and throw an error ', async () => {
+    const failedResult = await EvmApi.native
+      .getNFTTransfersByBlock({
+        blockNumberOrHash: '0x9b559aef7ea858608c2e554246fe4a24287e7aeeb976848df2b9a2531f4b917',
+      })
+      .then()
+      .catch((err) => {
+        return err;
+      });
+
+    expect(failedResult).toBeDefined();
+    expect(
+      EvmApi.native.getNFTTransfersByBlock({
+        blockNumberOrHash: '0x9b559aef7ea858608c2e554246fe4a24287e7aeeb976848df2b9a2531f4b917',
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"[C0005] Invalid address provided"`);
+  });
+});


### PR DESCRIPTION
---
name: Fetch and transform native.getNFTTransfersByBlock
about: Test to get NFT transfers by block.
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #

### Solution Description
Users can get NFT transfers by block.
<!-- Add a description of the solution in this PR. -->
