### PR TITLE
Web3Auth rpcTarget parameter addition

### DIFF
--- a/src/Web3Connector/Web3AuthConnector.js
+++ b/src/Web3Connector/Web3AuthConnector.js
@@ -21,7 +21,7 @@ export class Web3Auth extends AbstractWeb3Connector {
     });
   };
 
-  activate = async ({ chainId = '0x1', clientId, theme, appLogo, loginMethodsOrder } = {}) => {
+  activate = async ({ chainId = '0x1', clientId, theme, appLogo, loginMethodsOrder, rpcUrl } = {}) => {
     // Checking that all params are given
     if (!clientId) {
       throw new Error('"clientId" not provided, please provide clientId');
@@ -49,6 +49,7 @@ export class Web3Auth extends AbstractWeb3Connector {
     const ethChainConfig = {
       chainNamespace: 'eip155',
       chainId: verifyChainId(chainId),
+      rpcTarget: rpcUrl
     };
     // Build Web3Auth
     let web3auth;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -372,6 +372,7 @@ export namespace Moralis {
     theme?: string;
     appLogo?: string;
     loginMethodsOrder?: string[];
+    rpcUrl?: string;
   }
 
   interface Web3InjectedConnectorEnableOptions extends CommonEnableOptions {}


### PR DESCRIPTION
### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

CORS issues with default RPC(s) that Web3Auth uses

Related issue: https://forum.moralis.io/t/web3auth-mumbai-chain-blocked-by-cors/14533

### Solution Description

Add rpcUrl parameter for rpcTarget
