### PR TITLE
feat(evm): validate optional chain

### DIFF
--- a/demos/test-app-all/src/Evm.tsx
+++ b/demos/test-app-all/src/Evm.tsx
@@ -27,8 +27,9 @@ export const Evm = () => {
         onClick={async () => {
           console.log('Transfer native');
           const txResponse = await Moralis.Evm.transferNative({
-            to: '0x295522b61890c3672D12eFbFf4358a6411CE996F',
-            value: EvmNative.create('0.0001'),
+            to: '0x992eCcC191D6F74E8Be187ed6B6AC196b08314f7',
+            value: EvmNative.create('0.00001'),
+            chain: '0x4'
           });
 
           console.log('TX', txResponse);

--- a/packages/core/src/Error/ErrorCode.ts
+++ b/packages/core/src/Error/ErrorCode.ts
@@ -49,6 +49,7 @@ export enum NetworkErrorCode {
   WALLET_NOT_FOUND = 'N0006',
   CONTRACT_NOT_SET = 'N0007',
   NO_CHAIN_SET = 'N0008',
+  CHAIN_MISMATCH = 'N0009',
 
   NOT_IMPLEMENTED = 'N9000',
 }

--- a/packages/evm/src/chainMethods/transferErc1155.ts
+++ b/packages/evm/src/chainMethods/transferErc1155.ts
@@ -1,8 +1,10 @@
 import { EvmAddress, EvmAddressish, EvmChainish } from '@moralisweb3/core';
 import { BigNumber, BigNumberish, BytesLike, ethers } from 'ethers';
 import { assertAddress } from '../assert/assertAddress';
+import { assertChain } from '../assert/assertChain';
 import { assertProvider } from '../assert/assertProvider';
 import { Erc1155__factory } from '../Contract';
+import { validateChain } from '../utils/validators';
 import { wrapEthersTransactionResponse } from '../utils/wrapEthersTransactionResponse';
 
 export interface TransferErc1155Options {
@@ -19,8 +21,9 @@ export const makeTransferErc1155 =
   async (options: TransferErc1155Options) => {
     const provider = assertProvider(_provider);
     const fromAddress = assertAddress(_account, 'No account is connected');
+    const chain = assertChain(_chain, 'Chain is not set on MoralisEvm. Make sure to be properly connected');
 
-    // TODO: validate that provided chain is current chain
+    if (options.chain) validateChain(options.chain, chain);
 
     const contractAddress = EvmAddress.create(options.contractAddress);
     const toAddress = EvmAddress.create(options.to);
@@ -32,5 +35,5 @@ export const makeTransferErc1155 =
 
     const response = await token.safeTransferFrom(fromAddress.checksum, toAddress.checksum, tokenId, value, data);
 
-    return wrapEthersTransactionResponse(response, _chain);
+    return wrapEthersTransactionResponse(response, chain);
   };

--- a/packages/evm/src/chainMethods/transferErc20.ts
+++ b/packages/evm/src/chainMethods/transferErc20.ts
@@ -1,7 +1,9 @@
 import { Erc20Value, Erc20Valueish, EvmAddress, EvmAddressish, EvmChainish } from '@moralisweb3/core';
 import { ethers } from 'ethers';
+import { assertChain } from '../assert/assertChain';
 import { assertProvider } from '../assert/assertProvider';
 import { Erc20__factory } from '../Contract';
+import { validateChain } from '../utils/validators';
 import { wrapEthersTransactionResponse } from '../utils/wrapEthersTransactionResponse';
 
 export interface TransferErc20Options {
@@ -16,7 +18,8 @@ export const makeTransferErc20 =
   async (options: TransferErc20Options) => {
     const provider = assertProvider(_provider);
 
-    // TODO: validate that provided chain is current chain
+    const chain = assertChain(_chain, 'Chain is not set on MoralisEvm. Make sure to be properly connected');
+    if (options.chain) validateChain(options.chain, chain);
 
     const contractAddress = EvmAddress.create(options.contractAddress);
     const toAddress = EvmAddress.create(options.to);

--- a/packages/evm/src/chainMethods/transferErc721.ts
+++ b/packages/evm/src/chainMethods/transferErc721.ts
@@ -1,8 +1,10 @@
 import { EvmAddress, EvmAddressish, EvmChainish } from '@moralisweb3/core';
 import { BigNumberish, ethers } from 'ethers';
 import { assertAddress } from '../assert/assertAddress';
+import { assertChain } from '../assert/assertChain';
 import { assertProvider } from '../assert/assertProvider';
 import { Erc721__factory } from '../Contract';
+import { validateChain } from '../utils/validators';
 import { wrapEthersTransactionResponse } from '../utils/wrapEthersTransactionResponse';
 
 export interface TransferErc721Options {
@@ -18,7 +20,8 @@ export const makeTransferErc721 =
     const provider = assertProvider(_provider);
     const fromAddress = assertAddress(_account, 'No account is connected');
 
-    // TODO: validate that provided chain is current chain
+    const chain = assertChain(_chain, 'Chain is not set on MoralisEvm. Make sure to be properly connected');
+    if (options.chain) validateChain(options.chain, chain);
 
     const contractAddress = EvmAddress.create(options.contractAddress);
     const toAddress = EvmAddress.create(options.to);
@@ -32,5 +35,5 @@ export const makeTransferErc721 =
       tokenId,
     );
 
-    return wrapEthersTransactionResponse(response, _chain);
+    return wrapEthersTransactionResponse(response, chain);
   };

--- a/packages/evm/src/chainMethods/transferNative.ts
+++ b/packages/evm/src/chainMethods/transferNative.ts
@@ -9,6 +9,7 @@ import {
   EvmTransactionResponse,
 } from '@moralisweb3/core';
 import { assertChain } from '../assert/assertChain';
+import { validateChain } from '../utils/validators';
 
 export interface TransferNativeOptions {
   to: EvmAddressish;
@@ -21,8 +22,8 @@ export const makeTransferNative =
   async (options: TransferNativeOptions) => {
     const to = EvmAddress.create(options.to);
     const value = EvmNative.create(options.value);
-    // TODO: check if provided chain is same as current chain, otherwise throw error
     const chain = assertChain(_chain, 'Chain is not set on MoralisEvm. Make sure to be properly connected');
+    if (options.chain) validateChain(options.chain, chain);
 
     const transaction = await sendTransaction({
       to: to.checksum,

--- a/packages/evm/src/utils/validators.ts
+++ b/packages/evm/src/utils/validators.ts
@@ -1,0 +1,10 @@
+import { EvmChain, EvmChainish, MoralisNetworkError, NetworkErrorCode } from '@moralisweb3/core';
+
+export const validateChain = (providedChain: EvmChainish, chain: EvmChain): void => {
+  if (!chain.equals(providedChain)) {
+    throw new MoralisNetworkError({
+      code: NetworkErrorCode.CHAIN_MISMATCH,
+      message: 'Provided chain does not match evm connected chain',
+    });
+  }
+};


### PR DESCRIPTION
When calling transferNative, and any other Evm functionalities, we can
let the user provide a chain (EvmChainish). When they do, we check if
the provided chain corresponds the current chain. If that is not the
case we throw an error.

---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [X] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [X] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [X] I have made corresponding changes to the documentation
- [X] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #`FILL_THIS_OUT`

### Solution Description

<!-- Add a description of the solution in this PR. -->
