### PR TITLE
perf(datatypes): cleanup validations

### DIFF
--- a/packages/core/src/dataTypes/EvmAddress.ts
+++ b/packages/core/src/dataTypes/EvmAddress.ts
@@ -27,22 +27,28 @@ export class EvmAddress implements MoralisData {
     return new EvmAddress(address);
   }
 
-  static validate(address: InputEvmAddress) {
+  // TODO: remove comments when implemented
+  // static validate(address: InputEvmAddress) {
+  //   if (!isAddress(address)) {
+  //     throw new MoralisCoreError({
+  //       code: CoreErrorCode.INVALID_ARGUMENT,
+  //       message: 'Invalid address provided',
+  //     });
+  //   }
+
+  //   return true;
+  // }
+
+  /**
+   * Parse the input to a value that is compatible with the internal _value
+   */
+  static parse(address: InputEvmAddress) {
     if (!isAddress(address)) {
       throw new MoralisCoreError({
         code: CoreErrorCode.INVALID_ARGUMENT,
         message: 'Invalid address provided',
       });
     }
-
-    return true;
-  }
-
-  /**
-   * Parse the input to a value that is compatible with the internal _value
-   */
-  static parse(address: InputEvmAddress) {
-    EvmAddress.validate(address);
     return getAddress(address);
   }
 

--- a/packages/core/src/dataTypes/EvmAddress.ts
+++ b/packages/core/src/dataTypes/EvmAddress.ts
@@ -27,18 +27,6 @@ export class EvmAddress implements MoralisData {
     return new EvmAddress(address);
   }
 
-  // TODO: remove comments when implemented
-  // static validate(address: InputEvmAddress) {
-  //   if (!isAddress(address)) {
-  //     throw new MoralisCoreError({
-  //       code: CoreErrorCode.INVALID_ARGUMENT,
-  //       message: 'Invalid address provided',
-  //     });
-  //   }
-
-  //   return true;
-  // }
-
   /**
    * Parse the input to a value that is compatible with the internal _value
    */

--- a/packages/core/src/dataTypes/EvmChain.ts
+++ b/packages/core/src/dataTypes/EvmChain.ts
@@ -70,35 +70,6 @@ export class EvmChain implements MoralisData {
     return new EvmChain(chain);
   }
 
-  // TODO: Remove comment when implemented
-  // static validate(chain: InputChainId) {
-  //   if (typeof chain === 'string') {
-  //     if (isSupportedChainName(chain)) {
-  //       return true;
-  //     }
-
-  //     if (chain.startsWith('0x') && chain !== '0x' && chain !== '0x0') {
-  //       return true;
-  //     }
-
-  //     throw new MoralisCoreError({
-  //       code: CoreErrorCode.INVALID_ARGUMENT,
-  //       message:
-  //         "Invalid provided chain, value must be a positive number, chain-name or a hex-string starting with '0x'",
-  //     });
-  //   } else {
-  //     if (chain <= 0) {
-  //       throw new MoralisCoreError({
-  //         code: CoreErrorCode.INVALID_ARGUMENT,
-  //         message:
-  //           "Invalid provided chain, value must be a positive number, chain-name or a hex-string starting with '0x'",
-  //       });
-  //     }
-  //   }
-
-  //   return true;
-  // }
-
   /**
    * Parse the input to a value that is compatible with the internal _value
    */

--- a/packages/core/src/dataTypes/EvmChain.ts
+++ b/packages/core/src/dataTypes/EvmChain.ts
@@ -70,16 +70,47 @@ export class EvmChain implements MoralisData {
     return new EvmChain(chain);
   }
 
-  static validate(chain: InputChainId) {
+  // TODO: Remove comment when implemented
+  // static validate(chain: InputChainId) {
+  //   if (typeof chain === 'string') {
+  //     if (isSupportedChainName(chain)) {
+  //       return true;
+  //     }
+
+  //     if (chain.startsWith('0x') && chain !== '0x' && chain !== '0x0') {
+  //       return true;
+  //     }
+
+  //     throw new MoralisCoreError({
+  //       code: CoreErrorCode.INVALID_ARGUMENT,
+  //       message:
+  //         "Invalid provided chain, value must be a positive number, chain-name or a hex-string starting with '0x'",
+  //     });
+  //   } else {
+  //     if (chain <= 0) {
+  //       throw new MoralisCoreError({
+  //         code: CoreErrorCode.INVALID_ARGUMENT,
+  //         message:
+  //           "Invalid provided chain, value must be a positive number, chain-name or a hex-string starting with '0x'",
+  //       });
+  //     }
+  //   }
+
+  //   return true;
+  // }
+
+  /**
+   * Parse the input to a value that is compatible with the internal _value
+   */
+  static parse(chain: InputChainId) {
     if (typeof chain === 'string') {
       if (isSupportedChainName(chain)) {
-        return true;
+        return chainNameToChainIdMap[chain];
       }
 
       if (chain.startsWith('0x') && chain !== '0x' && chain !== '0x0') {
-        return true;
+        return chain;
       }
-
       throw new MoralisCoreError({
         code: CoreErrorCode.INVALID_ARGUMENT,
         message:
@@ -93,24 +124,8 @@ export class EvmChain implements MoralisData {
             "Invalid provided chain, value must be a positive number, chain-name or a hex-string starting with '0x'",
         });
       }
+      return `0x${chain.toString(16)}`;
     }
-
-    return true;
-  }
-
-  /**
-   * Parse the input to a value that is compatible with the internal _value
-   */
-  static parse(chain: InputChainId) {
-    EvmChain.validate(chain);
-    if (typeof chain === 'string') {
-      if (isSupportedChainName(chain)) {
-        return chainNameToChainIdMap[chain];
-      }
-
-      return chain;
-    }
-    return `0x${chain.toString(16)}`;
   }
 
   /**


### PR DESCRIPTION
Some datatypes have separate validation methods. This results in
duplicate logic, as we also validate during the parse. This PR puts
validation just in the parse function

---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [X] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [X] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [X] I have made corresponding changes to the documentation
- [X] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->

Related issue: #`FILL_THIS_OUT`

### Solution Description

<!-- Add a description of the solution in this PR. -->
