### PR TITLE
(feat):adding creation of EVMaddress using ens

### DIFF
--- a/packages/evmUtils/package.json
+++ b/packages/evmUtils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moralisweb3/evm-utils",
   "author": "Moralis",
-  "version": "2.5.3",
+  "version": "2.4.0",
   "license": "MIT",
   "private": false,
   "main": "./lib/index.js",
@@ -26,7 +26,9 @@
   },
   "dependencies": {
     "@ethersproject/address": "^5.6.0",
+    "@ethersproject/hash": "^5.7.0",
+    "@ethersproject/providers": "^5.7.1",
     "@ethersproject/transactions": "^5.6.0",
-    "@moralisweb3/core": "^2.5.3"
+    "@moralisweb3/core": "^2.4.0"
   }
 }

--- a/packages/evmUtils/src/dataTypes/EvmAddress/EvmAddress.test.ts
+++ b/packages/evmUtils/src/dataTypes/EvmAddress/EvmAddress.test.ts
@@ -6,6 +6,8 @@ const TEST_ADDRESS_CHECKSUM = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
 const TEST_ADDRESS_CHECKSUM2 = '0x766fd99F7D249E275b4CF9baE422D50cC3223869';
 const TEST_ADDRESS_LOWERCASE = TEST_ADDRESS_CHECKSUM.toLowerCase();
 const TEST_INVALID_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96000';
+const TEST_NAME = 'vitalik.eth';
+const TEST_CHAINID = 1;
 
 describe('EvmAddress', () => {
   let core: MoralisCore;
@@ -25,6 +27,11 @@ describe('EvmAddress', () => {
     const address = EvmAddress.create(TEST_ADDRESS_LOWERCASE);
 
     expect(address.format()).toBe(TEST_ADDRESS_LOWERCASE);
+  });
+
+  it('should create a new EvmAddress based on a name', async () => {
+    jest.setTimeout(12000);
+    await EvmAddress.createFromENS(TEST_NAME, TEST_CHAINID);
   });
 
   it('should create a new EvmAddress based on a checksum address', () => {
@@ -101,6 +108,7 @@ describe('EvmAddress', () => {
   /**
    * Methods
    */
+
   it('should check equality of 2 addresses of the same value', () => {
     const addressA = EvmAddress.create(TEST_ADDRESS_LOWERCASE);
     const addressB = EvmAddress.create(TEST_ADDRESS_CHECKSUM);

--- a/packages/evmUtils/src/dataTypes/EvmAddress/EvmAddress.ts
+++ b/packages/evmUtils/src/dataTypes/EvmAddress/EvmAddress.ts
@@ -7,8 +7,11 @@ import {
   MoralisCoreError,
   MoralisData,
 } from '@moralisweb3/core';
+import { InputChainId } from '../EvmChain';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { EvmUtilsConfig } from '../../config/EvmUtilsConfig';
+import { isValidName } from '@ethersproject/hash';
+import { getDefaultProvider } from '@ethersproject/providers';
 
 /**
  * This can be any valid EVM address, formatted as lowercase or checksum.
@@ -56,6 +59,30 @@ export class EvmAddress implements MoralisData {
     }
     const finalCore = core || MoralisCoreProvider.getDefault();
     return new EvmAddress(address, finalCore.config);
+  }
+
+  /**
+   * Create a new instance of EvmAddress from any ens name
+   *
+   * @example
+   * ```
+   * const address = EvmAddress.createFromENS("vitalik.eth")
+   * const address = EvmAddress.createFromENS("bart.eth")
+   *
+   * ```
+   */
+  public static async createFromENS(name: string, network?: InputChainId, core?: MoralisCore) {
+    if (!isValidName(name)) {
+      throw new MoralisCoreError({
+        code: CoreErrorCode.INVALID_ARGUMENT,
+        message: 'Invalid name provided',
+      });
+    }
+
+    const provider = getDefaultProvider(network);
+    const address = await provider.resolveName(name);
+
+    return this.create(address!, core);
   }
 
   /**

--- a/packages/evmUtils/src/dataTypes/EvmChain/EvmChainish.ts
+++ b/packages/evmUtils/src/dataTypes/EvmChain/EvmChainish.ts
@@ -1,6 +1,6 @@
 import { EvmChain } from './EvmChain';
 
-// hex-string, ChainNameor a number
+// hex-string, ChainName or a number
 export type InputChainId = string | number;
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3187,6 +3187,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@^5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.1.tgz#b0799b616d5579cd1067a8ebf1fc1ec74c1e122c"
+  integrity sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.0.tgz#1505d1ab6a250e0ee92f436850fa3314b2cb5ae6"
@@ -4501,6 +4527,15 @@
   version "2.0.0"
   resolved "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
+
+"@moralisweb3/evm-utils@^2.5.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@moralisweb3/evm-utils/-/evm-utils-2.5.3.tgz#5fec37c9aed3e9b19843f8095e4489bf930d22cb"
+  integrity sha512-Pr+oiy8BAGyLAkLSVnx8P6ZS08XSLYuaPipm/8UFduBDbou7yIcmtsoKiIFWCjeLvFpb9ElAft1lFmNhdSu5aw==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@moralisweb3/core" "^2.5.3"
 
 "@moralisweb3/streams-typings@^1.0.2":
   version "1.0.2"


### PR DESCRIPTION
---
name: 'adding creation of EVMaddress using ens'
about: Currently, EvmAddress are created via EvmAddress.create("0x12423fsa"). A nice feature would be to create an address via ENS.
This will be an async call so we can add a new static method like await EvmAddress.createFromENS("name.eth")
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

<!-- Add a brief description of the issue this PR solves. -->


### Solution Description

<!-- Add a description of the solution in this PR. -->
- Added ethersjs based name resolution for evmaddress
- Added tests for the same
To do
- support for user passed parameter of specific rpc urls while creating provider
