### PR TITLE
cli demo: add typescript as dev dependency

### DIFF
--- a/demos/cli/package.json
+++ b/demos/cli/package.json
@@ -22,6 +22,7 @@
     "eslint-plugin-etc": "^2.0.2",
     "eslint-plugin-import": "^2.26.0",
     "@types/node": "^18.7.14",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
---
name: 'cli demo: add typescript as dev dependency'
about: A new pull request
---

## cli demo: add typescript as dev dependency

### Checklist

- [X] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [X] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [X] I have made corresponding changes to the documentation
- [X] I have updated Typescript definitions when needed

### Issue Description

When building [*cli* demo](https://github.com/MoralisWeb3/Moralis-JS-SDK/tree/main/demos/cli) without Typescript globally installed, I'm getting this error:

```shell
~/Desktop/cli via  v18.11.0 
➜ yarn run build
yarn run v1.22.19
$ tsc
/bin/sh: line 1: tsc: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### Solution Description

After adding to [`package.json`](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/demos/cli/package.json) / devDependencies the `"typescript": "^4.8.4"` I'm able to build without problems:

```shell
~/Desktop/cli via  v18.11.0 took 6s 
➜ yarn run build
yarn run v1.22.19
$ tsc
Done in 1.10s.
```