### PR TITLE
separate common-core and umbrella package configs

### DIFF
--- a/demos/firebase-proxy/functions/tsconfig.json
+++ b/demos/firebase-proxy/functions/tsconfig.json
@@ -7,7 +7,8 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2017",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "esModuleInterop": true
   },
   "compileOnSave": true,
   "include": ["src"]

--- a/packages/apiUtils/src/config/MoralisConfig.ts
+++ b/packages/apiUtils/src/config/MoralisConfig.ts
@@ -1,0 +1,4 @@
+// @moralisweb3/api-utils
+export interface ApiUtilsConfigValues {
+  apiKey: string;
+}

--- a/packages/apiUtils/src/config/index.ts
+++ b/packages/apiUtils/src/config/index.ts
@@ -1,1 +1,2 @@
 export * from './ApiUtilsConfig';
+export * from './MoralisConfig';

--- a/packages/common/core/src/Config/MoralisConfig.ts
+++ b/packages/common/core/src/Config/MoralisConfig.ts
@@ -4,33 +4,32 @@ import { EvmChainish } from './interfaces/EvmChainish';
 
 // @moralisweb3/common-core
 type CoreConfigType = typeof CoreConfig;
-type CoreConfigValues = Omit<{ [Key in keyof CoreConfigType]: CoreConfigType[Key]['defaultValue'] }, 'product'>;
+export type CoreConfigValues = Omit<{ [Key in keyof CoreConfigType]: CoreConfigType[Key]['defaultValue'] }, 'product'>;
 
 // @moralisweb3/common-evm-utils
-interface EvmUtilsConfigValues {
+export interface EvmUtilsConfigValues {
   formatEvmAddress: EvmAddressFormat;
   formatEvmChainId: EvmChainIdFormat;
 }
 
 // @moralisweb3/api-utils
-interface ApiUtilsConfigValues {
+export interface ApiUtilsConfigValues {
   apiKey: string;
 }
 
 // @moralisweb3/evm-api
-interface EvmApiConfigValues {
+export interface EvmApiConfigValues {
   defaultEvmApiChain: EvmChainish;
 }
 
 // @moralisweb3/sol-api
-interface SolApiConfigValues {
+export interface SolApiConfigValues {
   defaultSolNetwork: SolNetworkish;
 }
 
-export type MoralisConfigValues =
+export type MoralisCoreConfigValues =
   | CoreConfigValues
   | EvmUtilsConfigValues
-  | ApiUtilsConfigValues
   | EvmApiConfigValues
   | SolApiConfigValues
   // Other, not strong typed values.

--- a/packages/common/core/src/Config/MoralisConfig.ts
+++ b/packages/common/core/src/Config/MoralisConfig.ts
@@ -12,11 +12,6 @@ export interface EvmUtilsConfigValues {
   formatEvmChainId: EvmChainIdFormat;
 }
 
-// @moralisweb3/api-utils
-export interface ApiUtilsConfigValues {
-  apiKey: string;
-}
-
 // @moralisweb3/evm-api
 export interface EvmApiConfigValues {
   defaultEvmApiChain: EvmChainish;

--- a/packages/common/core/src/Core.ts
+++ b/packages/common/core/src/Core.ts
@@ -3,7 +3,7 @@ import { Modules } from './Modules/Modules';
 import { LoggerController } from './controllers/LoggerController';
 import { Config } from './Config/Config';
 import { CoreConfigSetup } from './Config/CoreConfigSetup';
-import { MoralisConfigValues } from './Config';
+import { MoralisCoreConfigValues } from './Config';
 import { LIB_VERSION } from './version';
 import { CoreErrorCode, MoralisError } from './Error';
 
@@ -68,7 +68,7 @@ export class Core {
    *
    * This will call `start()` on every registered module
    */
-  public start = async (providedConfig?: Partial<MoralisConfigValues>) => {
+  public start = async (providedConfig?: Partial<MoralisCoreConfigValues>) => {
     if (this.isStarted) {
       throw new MoralisError({
         message: 'Modules are started already. This method should be called only one time.',

--- a/packages/common/core/src/dataTypes/BigNumber/index.ts
+++ b/packages/common/core/src/dataTypes/BigNumber/index.ts
@@ -1,2 +1,2 @@
 export * from './BigNumber';
-export { BigNumberPrimitive } from './BigNumberParser';
+export type { BigNumberPrimitive } from './BigNumberParser';

--- a/packages/moralis/src/Config/MoralisConfig.ts
+++ b/packages/moralis/src/Config/MoralisConfig.ts
@@ -1,3 +1,0 @@
-import { ApiUtilsConfigValues, MoralisCoreConfigValues } from '@moralisweb3/common-core/src/index';
-
-export type MoralisConfigValues = MoralisCoreConfigValues | ApiUtilsConfigValues;

--- a/packages/moralis/src/Config/MoralisConfig.ts
+++ b/packages/moralis/src/Config/MoralisConfig.ts
@@ -1,0 +1,8 @@
+import {
+  ApiUtilsConfigValues,
+  MoralisCoreConfigValues,
+} from '@moralisweb3/common-core/src/index';
+
+export type MoralisConfigValues =
+  | MoralisCoreConfigValues
+  | ApiUtilsConfigValues;

--- a/packages/moralis/src/Config/MoralisConfig.ts
+++ b/packages/moralis/src/Config/MoralisConfig.ts
@@ -1,8 +1,3 @@
-import {
-  ApiUtilsConfigValues,
-  MoralisCoreConfigValues,
-} from '@moralisweb3/common-core/src/index';
+import { ApiUtilsConfigValues, MoralisCoreConfigValues } from '@moralisweb3/common-core/src/index';
 
-export type MoralisConfigValues =
-  | MoralisCoreConfigValues
-  | ApiUtilsConfigValues;
+export type MoralisConfigValues = MoralisCoreConfigValues | ApiUtilsConfigValues;

--- a/packages/moralis/src/config/MoralisConfig.ts
+++ b/packages/moralis/src/config/MoralisConfig.ts
@@ -1,0 +1,4 @@
+import { MoralisCoreConfigValues } from '@moralisweb3/common-core';
+import { ApiUtilsConfigValues } from '@moralisweb3/api-utils';
+
+export type MoralisConfigValues = MoralisCoreConfigValues | ApiUtilsConfigValues;

--- a/packages/moralis/src/index.ts
+++ b/packages/moralis/src/index.ts
@@ -7,6 +7,8 @@ import { CommonSolUtils } from '@moralisweb3/common-sol-utils';
 import { SolApi } from '@moralisweb3/sol-api';
 import { Core, CoreProvider } from '@moralisweb3/common-core';
 
+import { MoralisConfigValues } from './Config/MoralisConfig';
+
 // Core
 const core = Core.create();
 
@@ -34,7 +36,9 @@ const Moralis = {
   EvmApi: evmApi,
   SolApi: solApi,
 
-  start: core.start,
+  start: (config?: Partial<MoralisConfigValues>) => {
+    return core.start(config);
+  },
 };
 
 export default Moralis;

--- a/packages/moralis/src/index.ts
+++ b/packages/moralis/src/index.ts
@@ -7,7 +7,7 @@ import { CommonSolUtils } from '@moralisweb3/common-sol-utils';
 import { SolApi } from '@moralisweb3/sol-api';
 import { Core, CoreProvider } from '@moralisweb3/common-core';
 
-import { MoralisConfigValues } from './Config/MoralisConfig';
+import { MoralisConfigValues } from './config/MoralisConfig';
 
 // Core
 const core = Core.create();


### PR DESCRIPTION
---
name: 'common-core parameters not using all possible options from umbrella'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

This PR solves that when starting the common core package you are offered to pass an apiKey, which is not needed and should not be used on FE

Related issue: #`FILL_THIS_OUT`

### Solution Description

<!-- Add a description of the solution in this PR. -->
