### PR TITLE
validate return property names for getRequestUrlParams() methods.

### DIFF
--- a/packages/common/evmUtils/src/operations/operations.test.ts
+++ b/packages/common/evmUtils/src/operations/operations.test.ts
@@ -12,7 +12,7 @@ describe('operations', () => {
   for (const operation of operations) {
     describe(operation.name, () => {
       it('defines all supported parameters', () => {
-        const openApiPathParamNames = reader.readOperationPathParamNames(operation.id);
+        const openApiPathParamNames = reader.readOperationPathParamNames(operation.id)?.map(toCamel);
         const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id)?.map(toCamel);
         const openApiBodyParamNames = reader.readOperationRequestBodyParamNames(operation.id)?.map(toCamel);
 
@@ -23,16 +23,16 @@ describe('operations', () => {
 
       it(`getRequestUrlParams() function returns all supported property names`, () => {
         const openApiPathParamNames = reader.readOperationPathParamNames(operation.id)?.map(toCamel);
-        const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id);
+        const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id); // Must be same as in API
 
         const definitionReader = new OperationDefinitionReader(
           `src/operations/${operation.groupName}/${operation.name}Operation.ts`,
         );
-        const returnPropertyNames = definitionReader.getRequestUrlParamsFunctionReturnPropertyNames().sort();
+        const returnPropertyNames = definitionReader.getRequestUrlParamsFunctionReturnPropertyNames();
 
-        const expectedPropertyNames = [...(openApiPathParamNames || []), ...(openApiSearchParamNames || [])].sort();
+        const expectedPropertyNames = [...(openApiPathParamNames || []), ...(openApiSearchParamNames || [])];
 
-        expect(returnPropertyNames.join(',')).toBe(expectedPropertyNames.join(','));
+        expect(returnPropertyNames.sort().join(',')).toBe(expectedPropertyNames.sort().join(','));
       });
     });
   }

--- a/packages/common/evmUtils/src/operations/operations.test.ts
+++ b/packages/common/evmUtils/src/operations/operations.test.ts
@@ -1,5 +1,5 @@
 import { toCamel } from '@moralisweb3/common-core';
-import { OpenApiInterfaceReader } from '@moralisweb3/test-utils';
+import { OpenApiInterfaceReader, OperationDefinitionReader } from '@moralisweb3/test-utils';
 import { operations } from './operations';
 
 describe('operations', () => {
@@ -10,14 +10,30 @@ describe('operations', () => {
   });
 
   for (const operation of operations) {
-    it(`${operation.name} defines all supported parameters`, () => {
-      const openApiPathParamNames = reader.readOperationPathParamNames(operation.id);
-      const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id)?.map(toCamel);
-      const openApiBodyParamNames = reader.readOperationRequestBodyParamNames(operation.id)?.map(toCamel);
+    describe(operation.name, () => {
+      it('defines all supported parameters', () => {
+        const openApiPathParamNames = reader.readOperationPathParamNames(operation.id);
+        const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id)?.map(toCamel);
+        const openApiBodyParamNames = reader.readOperationRequestBodyParamNames(operation.id)?.map(toCamel);
 
-      expect(operation.urlPathParamNames.sort().join(',')).toBe(openApiPathParamNames?.sort().join(','));
-      expect(operation.urlSearchParamNames?.sort().join(',')).toBe(openApiSearchParamNames?.sort().join(','));
-      expect(operation.bodyParamNames?.sort().join(',')).toBe(openApiBodyParamNames?.sort().join(','));
+        expect(operation.urlPathParamNames.sort().join(',')).toBe(openApiPathParamNames?.sort().join(','));
+        expect(operation.urlSearchParamNames?.sort().join(',')).toBe(openApiSearchParamNames?.sort().join(','));
+        expect(operation.bodyParamNames?.sort().join(',')).toBe(openApiBodyParamNames?.sort().join(','));
+      });
+
+      it(`getRequestUrlParams() function returns all supported property names`, () => {
+        const openApiPathParamNames = reader.readOperationPathParamNames(operation.id)?.map(toCamel);
+        const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id);
+
+        const definitionReader = new OperationDefinitionReader(
+          `src/operations/${operation.groupName}/${operation.name}Operation.ts`,
+        );
+        const returnPropertyNames = definitionReader.getRequestUrlParamsFunctionReturnPropertyNames().sort();
+
+        const expectedPropertyNames = [...(openApiPathParamNames || []), ...(openApiSearchParamNames || [])].sort();
+
+        expect(returnPropertyNames.join(',')).toBe(expectedPropertyNames.join(','));
+      });
     });
   }
 });

--- a/packages/common/evmUtils/src/operations/token/getWalletTokenTransfersOperation.ts
+++ b/packages/common/evmUtils/src/operations/token/getWalletTokenTransfersOperation.ts
@@ -49,6 +49,7 @@ function getRequestUrlParams(request: GetWalletTokenTransfersRequest, core: Core
     address: EvmAddress.create(request.address, core).lowercase,
     chain: EvmChainResolver.resolve(request.chain, core).apiHex,
     cursor: request.cursor,
+    subdomain: request.subdomain,
     limit: maybe(request.limit, String),
     to_block: maybe(request.toBlock, String),
     from_block: maybe(request.fromBlock, String),

--- a/packages/common/evmUtils/src/operations/utils/runContractFunctionOperation.ts
+++ b/packages/common/evmUtils/src/operations/utils/runContractFunctionOperation.ts
@@ -33,7 +33,7 @@ export const runContractFunctionOperation: Operation<
   method: 'POST',
   name: 'runContractFunction',
   id: 'runContractFunction',
-  groupName: 'token',
+  groupName: 'utils',
   urlPathParamNames: ['address'],
   urlSearchParamNames: ['chain', 'functionName', 'providerUrl', 'subdomain'],
   urlPathPattern: '/{address}/function',
@@ -53,7 +53,7 @@ function getRequestUrlParams(request: RunContractFunctionRequest, core: Core) {
   return {
     address: EvmAddress.create(request.address, core).lowercase,
     chain: EvmChainResolver.resolve(request.chain, core).apiHex,
-    functionName: request.functionName,
+    function_name: request.functionName,
     providerUrl: request.providerUrl,
     subdomain: request.subdomain,
   };

--- a/packages/common/solUtils/src/operations/operations.test.ts
+++ b/packages/common/solUtils/src/operations/operations.test.ts
@@ -12,7 +12,7 @@ describe('operations', () => {
   for (const operation of operations) {
     describe(operation.name, () => {
       it('defines all supported parameters', () => {
-        const openApiPathParamNames = reader.readOperationPathParamNames(operation.id);
+        const openApiPathParamNames = reader.readOperationPathParamNames(operation.id)?.map(toCamel);
         const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id)?.map(toCamel);
         const openApiBodyParamNames = reader.readOperationRequestBodyParamNames(operation.id)?.map(toCamel);
 
@@ -23,16 +23,16 @@ describe('operations', () => {
 
       it(`getRequestUrlParams() function returns all supported property names`, () => {
         const openApiPathParamNames = reader.readOperationPathParamNames(operation.id)?.map(toCamel);
-        const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id);
+        const openApiSearchParamNames = reader.readOperationSearchParamNames(operation.id); // Must be same as in API
 
         const definitionReader = new OperationDefinitionReader(
           `src/operations/${operation.groupName}/${operation.name}Operation.ts`,
         );
-        const returnPropertyNames = definitionReader.getRequestUrlParamsFunctionReturnPropertyNames().sort();
+        const returnPropertyNames = definitionReader.getRequestUrlParamsFunctionReturnPropertyNames();
 
-        const expectedPropertyNames = [...(openApiPathParamNames || []), ...(openApiSearchParamNames || [])].sort();
+        const expectedPropertyNames = [...(openApiPathParamNames || []), ...(openApiSearchParamNames || [])];
 
-        expect(returnPropertyNames.join(',')).toBe(expectedPropertyNames.join(','));
+        expect(returnPropertyNames.sort().join(',')).toBe(expectedPropertyNames.sort().join(','));
       });
     });
   }

--- a/packages/testUtils/src/index.ts
+++ b/packages/testUtils/src/index.ts
@@ -1,3 +1,3 @@
 export * from './MockScenarios';
 export * from './MockServer';
-export * from './openapi';
+export * from './operations';

--- a/packages/testUtils/src/openapi/index.ts
+++ b/packages/testUtils/src/openapi/index.ts
@@ -1,1 +1,0 @@
-export * from './OpenApiInterfaceReader';

--- a/packages/testUtils/src/operations/OpenApiInterfaceReader.ts
+++ b/packages/testUtils/src/operations/OpenApiInterfaceReader.ts
@@ -11,6 +11,7 @@ import {
   PropertySignature,
   SourceFile,
 } from 'typescript';
+import { TsNodeWalker } from './TsNodeWalker';
 
 export class OpenApiInterfaceReader {
   private readonly sourceFile: SourceFile;
@@ -25,7 +26,7 @@ export class OpenApiInterfaceReader {
   }
 
   private getInterfaceNode(name: string): Node {
-    const result = process(this.sourceFile, (child) => {
+    const result = TsNodeWalker.traverse(this.sourceFile, (child) => {
       return isInterfaceDeclaration(child) && child.name.text === name ? child : null;
     });
     if (result.length !== 1) {
@@ -37,7 +38,7 @@ export class OpenApiInterfaceReader {
   private findLastNode(node: Node, path: string[]) {
     function find(parent: Node, pathIndex: number): PropertySignature | null {
       const name = path[pathIndex];
-      const result = process(parent, (child) => {
+      const result = TsNodeWalker.traverse(parent, (child) => {
         if (
           isPropertySignature(child) &&
           (isIdentifier(child.name) || isStringLiteral(child.name)) &&
@@ -63,7 +64,7 @@ export class OpenApiInterfaceReader {
   }
 
   private readPropertyNames(node: Node): string[] {
-    return process(node, (child) => {
+    return TsNodeWalker.traverse(node, (child) => {
       return isPropertySignature(child) && isIdentifier(child.name) ? child.name.text : null;
     });
   }
@@ -100,15 +101,4 @@ export class OpenApiInterfaceReader {
     }
     return null;
   }
-}
-
-function process<Value>(parent: Node, processor: (child: Node) => Value | null): Value[] {
-  const values: Value[] = [];
-  parent.forEachChild((child) => {
-    const value = processor(child);
-    if (value) {
-      values.push(value);
-    }
-  });
-  return values;
 }

--- a/packages/testUtils/src/operations/OperationDefinitionReader.ts
+++ b/packages/testUtils/src/operations/OperationDefinitionReader.ts
@@ -1,0 +1,49 @@
+/* eslint-disable complexity */
+import {
+  createProgram,
+  isFunctionDeclaration,
+  isIdentifier,
+  isObjectLiteralExpression,
+  isReturnStatement,
+  SourceFile,
+} from 'typescript';
+import { TsNodeWalker } from './TsNodeWalker';
+
+export class OperationDefinitionReader {
+  private readonly sourceFile: SourceFile;
+
+  public constructor(tsFilePath: string) {
+    const program = createProgram([tsFilePath], {});
+    const sourceFile = program.getSourceFile(tsFilePath);
+    if (!sourceFile) {
+      throw new Error(`Cannot load source file ${tsFilePath}`);
+    }
+    this.sourceFile = sourceFile;
+  }
+
+  public getRequestUrlParamsFunctionReturnPropertyNames(): string[] {
+    const funcName = 'getRequestUrlParams';
+    const funcs = TsNodeWalker.traverse(this.sourceFile, (child) => {
+      return isFunctionDeclaration(child) && child.name?.text === funcName ? child : null;
+    });
+    if (funcs.length !== 1) {
+      throw new Error(`Cannot find function ${funcName}`);
+    }
+    const func = funcs[0];
+    if (func.body?.statements.length !== 1 || !isReturnStatement(func.body.statements[0])) {
+      throw new Error(`${funcName} function must have only one return statement`);
+    }
+    const returnStatement = func.body.statements[0];
+    if (!returnStatement.expression || !isObjectLiteralExpression(returnStatement.expression)) {
+      throw new Error(`${funcName} function must return object literal expression`);
+    }
+    const names: string[] = [];
+    for (let i = 0; i < returnStatement.expression.properties.length; i++) {
+      const { name } = returnStatement.expression.properties[i];
+      if (name && isIdentifier(name)) {
+        names.push(name.escapedText.toString());
+      }
+    }
+    return names;
+  }
+}

--- a/packages/testUtils/src/operations/TsNodeWalker.ts
+++ b/packages/testUtils/src/operations/TsNodeWalker.ts
@@ -1,0 +1,14 @@
+import { Node } from 'typescript';
+
+export class TsNodeWalker {
+  public static traverse<Value>(parent: Node, processor: (child: Node) => Value | null): Value[] {
+    const values: Value[] = [];
+    parent.forEachChild((child) => {
+      const value = processor(child);
+      if (value) {
+        values.push(value);
+      }
+    });
+    return values;
+  }
+}

--- a/packages/testUtils/src/operations/index.ts
+++ b/packages/testUtils/src/operations/index.ts
@@ -1,0 +1,2 @@
+export * from './OpenApiInterfaceReader';
+export * from './OperationDefinitionReader';


### PR DESCRIPTION
---
name: validate return property names for getRequestUrlParams() methods.
---
