### PR TITLE
fix: Missing wei type in format type

### DIFF
--- a/.changeset/proud-spiders-learn.md
+++ b/.changeset/proud-spiders-learn.md
@@ -1,0 +1,5 @@
+---
+"@moralisweb3/common-evm-utils": 2.8.2
+---
+
+fix: Missing wei type in format type

--- a/packages/common/evmUtils/src/dataTypes/EvmNftTrade/EvmNftTrade.ts
+++ b/packages/common/evmUtils/src/dataTypes/EvmNftTrade/EvmNftTrade.ts
@@ -49,7 +49,7 @@ export class EvmNftTrade implements MoralisDataObject {
     tokenAddress: EvmAddress.create(data.tokenAddress),
     priceTokenAddress: maybe(data.priceTokenAddress, EvmAddress.create),
     blockNumber: BigNumber.create(data.blockNumber),
-    price: EvmNative.create(data.price),
+    price: EvmNative.create(data.price, 'wei'),
     transactionIndex: +data.transactionIndex,
     blockTimestamp: dateInputToDate(data.blockTimestamp),
   });

--- a/packages/common/evmUtils/src/operations/nft/getNFTTradesOperation.ts
+++ b/packages/common/evmUtils/src/operations/nft/getNFTTradesOperation.ts
@@ -96,7 +96,7 @@ function deserializeResponse(jsonResponse: GetNFTTradesJSONResponse, request: Ge
       buyerAddress: EvmAddress.create(trade.buyer_address, core),
       marketplaceAddress: EvmAddress.create(trade.marketplace_address, core),
       tokenAddress: EvmAddress.create(trade.token_address as string, core),
-      price: EvmNative.create(trade.price),
+      price: EvmNative.create(trade.price, 'wei'),
       blockTimestamp: new Date(trade.block_timestamp),
       tokenIds: trade.token_ids as string[],
     }),


### PR DESCRIPTION
---
Missing wei type in format type)
---

Hi guys, I used the API (https://docs.moralis.io/reference/getnfttrades) but the response data in the field price is different between API and SDK because it misses the 'wei' like other files. 
Could you guys help me double-check it, thank you so much