### PR TITLE
fix: return proper error messages in nextjs

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -33,6 +33,7 @@
     "@moralisweb3/api-utils": "^2.11.0",
     "@moralisweb3/auth": "^2.11.0",
     "@moralisweb3/common-auth-utils": "^2.11.0",
+    "@moralisweb3/common-core": "^2.11.0",
     "@moralisweb3/evm-api": "^2.11.0",
     "@moralisweb3/sol-api": "^2.11.0",
     "axios": "^1.2.1",

--- a/packages/next/src/auth/MoralisNextAuthProvider.ts
+++ b/packages/next/src/auth/MoralisNextAuthProvider.ts
@@ -1,8 +1,9 @@
-import { LoggerController, Network } from 'moralis/common-core';
+import { Network } from 'moralis/common-core';
 import { OperationResolver } from '@moralisweb3/api-utils';
 import { verifyChallengeEvmOperation, verifyChallengeSolanaOperation } from '@moralisweb3/common-auth-utils';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import Moralis from 'moralis';
+import { serverLogger } from '../serverLogger';
 
 const MoralisNextAuthProvider = () =>
   /**
@@ -96,9 +97,9 @@ const MoralisNextAuthProvider = () =>
          * Defining and returning user profile
          */
         return { ...user, payload };
-      } catch (e) {
-        const logger = new LoggerController('Next', Moralis.Core.config);
-        logger.error(e);
+      } catch (error) {
+        serverLogger.error(`Unknown error in MoralisNextAuthProvider authorize ${error.message}`, { error });
+
         return null;
       }
     },

--- a/packages/next/src/serverLogger.ts
+++ b/packages/next/src/serverLogger.ts
@@ -1,0 +1,4 @@
+import { LoggerController } from '@moralisweb3/common-core';
+import Moralis from 'moralis';
+
+export const serverLogger = LoggerController.create('nextjs', Moralis.Core);

--- a/packages/next/src/utils/fetchers/fetcher.ts
+++ b/packages/next/src/utils/fetchers/fetcher.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 import Moralis from 'moralis';
 import { Operation } from 'moralis/common-core';
 export interface FetcherParams<TOperation, Request> {
@@ -18,9 +18,20 @@ async function fetcher<Request, Response, JSONResponse>(
 ) {
   endpoint = `/api/moralis/${endpoint}`;
 
-  const { data } = await axios.post<JSONResponse>(endpoint, operation.serializeRequest(request, Moralis.Core));
+  try {
+    const { data } = await axios.post<JSONResponse>(endpoint, operation.serializeRequest(request, Moralis.Core));
+    return operation.deserializeResponse(data, request, Moralis.Core);
+  } catch (error) {
+    // Overwrite error message if the nextjs api returns additional error details
+    if (isAxiosError(error)) {
+      const errorMessage = error.response?.data?.error;
+      if (errorMessage) {
+        error.message = errorMessage;
+      }
+    }
 
-  return operation.deserializeResponse(data, request, Moralis.Core);
+    throw error;
+  }
 }
 
 export default fetcher;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7736,6 +7736,7 @@ __metadata:
     "@moralisweb3/api-utils": ^2.11.0
     "@moralisweb3/auth": ^2.11.0
     "@moralisweb3/common-auth-utils": ^2.11.0
+    "@moralisweb3/common-core": ^2.11.0
     "@moralisweb3/evm-api": ^2.11.0
     "@moralisweb3/sol-api": ^2.11.0
     axios: ^1.2.1


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

- All errors show up as a generic 500 error

Related issue: #`FILL_THIS_OUT`

### Solution Description

- Use statusCode from the MoralisApi, otherwise if it's a user error return 400, otherwise return 500 with a default message
- Add a serverLogger to the nextApi, to log any unaccounted errors
- Resolve errors client-side when the NextJs returns an {error: 'some error'} response
