### PR TITLE
fix: resolving requestChallenge hooks

### DIFF
--- a/.changeset/forty-dragons-act.md
+++ b/.changeset/forty-dragons-act.md
@@ -1,0 +1,6 @@
+---
+'@moralisweb3/auth': patch
+'@moralisweb3/next': patch
+---
+
+Fix auth hooks for NextJs

--- a/.changeset/forty-dragons-act.md
+++ b/.changeset/forty-dragons-act.md
@@ -1,6 +1,5 @@
 ---
 '@moralisweb3/auth': patch
-'@moralisweb3/next': patch
 ---
 
 Fix auth hooks for NextJs

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -4,7 +4,14 @@ import { makeVerify, VerifyEvmOptions, VerifyOptions, VerifySolOptions } from '.
 import {
   VerifyChallengeSolanaResponseAdapter,
   VerifyChallengeEvmResponseAdapter,
+  RequestChallengeEvmResponseAdapter,
+  requestChallengeEvmOperation,
+  RequestChallengeEvmRequest,
+  RequestChallengeSolanaResponseAdapter,
+  requestChallengeSolanaOperation,
+  RequestChallengeSolanaRequest,
 } from '@moralisweb3/common-auth-utils';
+import { OperationResolver } from '@moralisweb3/api-utils';
 
 export const BASE_URL = 'https://authapi.moralis.io';
 
@@ -27,6 +34,23 @@ export class Auth extends ApiModule {
     // Nothing
   }
 
+  // Client-side compatible operation, structured in a predictable way as defined in the operation
+  // TODO: generate in seperate package "client-evm-auth" (similar to client-evm-auth)
+  public readonly evm = {
+    requestChallengeEvm: (request: RequestChallengeEvmRequest): Promise<RequestChallengeEvmResponseAdapter> => {
+      return new OperationResolver(requestChallengeEvmOperation, this.baseUrl, this.core).fetch(request);
+    },
+  };
+
+  // Client-side compatible operation, structured in a predictable way as defined in the operation
+  // TODO: generate in seperate package "client-evm-auth" (similar to client-evm-auth)
+  public readonly solana = {
+    requestChallengeSol: (request: RequestChallengeSolanaRequest): Promise<RequestChallengeSolanaResponseAdapter> => {
+      return new OperationResolver(requestChallengeSolanaOperation, this.baseUrl, this.core).fetch(request);
+    },
+  };
+
+  // Resolves to requestChallengeEvm/requestChallengeSol depending on provided options (defaults to evm)
   public requestMessage = (options: RequestMessageOptions) => makeRequestMessage(this.core)(options);
 
   // Function overloading to make typescript happy


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

After changing the logic of resolving operations in  NextJs, we have an issue. Auth is handled a bit different, as we don't export the resolvers directly, but rather a combined function.

Two possible solutions:
1. Change the NextJs hook to be compatible with `requestMessage` and pass the network as a parameter. Then we need to update `packages/next/src/MoralisNextApi/Modules.ts` to account for a "different kind" of operation resolver (not grouped)
2. Add additional groups/operations to Auth, that is compatible with swagger/our operations structure. 

I choose option 2 as it is more predictable and does not involve a breaking change in the NextJs package. In the future we could improve it by extending Auth from a ClientEvmAuth and ClientSolAuth (similar to what we do in EvmApi). This requires restructuring of the Auth make it able to extend multiple other "client" classes. I have omitted it for now as we are also in the discussions of making it easier to generate our Api modules, based on swagger (for the current beta).

