### PR TITLE
fix: consistent networkTypes fallback for streams

### DIFF
--- a/.changeset/nervous-doors-kick.md
+++ b/.changeset/nervous-doors-kick.md
@@ -1,0 +1,5 @@
+---
+'@moralisweb3/streams': patch
+---
+
+Make networkType behaviour consistent for all streams endpoints. For endpoints that accept a networkType, it will default to 'evm' when none is provided.

--- a/packages/streams/src/methods/addAddress.ts
+++ b/packages/streams/src/methods/addAddress.ts
@@ -7,10 +7,9 @@ import {
   AddAddressEvmRequest,
   AddAddressEvmResponseAdapter,
 } from '@moralisweb3/common-streams-utils';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface AddAddressEvmOptions extends AddAddressEvmRequest {
-  networkType?: 'evm';
-}
+export interface AddAddressEvmOptions extends AddAddressEvmRequest, CommonStreamNetworkOptions {}
 
 export type AddAddressOptions = AddAddressEvmOptions;
 

--- a/packages/streams/src/methods/create.ts
+++ b/packages/streams/src/methods/create.ts
@@ -4,23 +4,22 @@ import { createStreamEvmOperation, CreateStreamEvmRequest } from '@moralisweb3/c
 
 import { IncorrectNetworkError } from '../utils/IncorrectNetworkError';
 import { StreamNetwork } from '../utils/StreamNetwork';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface CreateStreamEvmOptions extends CreateStreamEvmRequest {
-  networkType?: 'evm';
-}
+export interface CreateStreamEvmOptions extends CreateStreamEvmRequest, CommonStreamNetworkOptions {}
 
 export type CreateStreamOptions = CreateStreamEvmOptions;
 
 export const makeCreateStream = (core: Core, baseUrl: string) => {
-  const fetcher = new OperationResolver(createStreamEvmOperation, baseUrl, core).fetch;
+  const evmFetcher = new OperationResolver(createStreamEvmOperation, baseUrl, core).fetch;
 
   return ({ networkType, ...options }: CreateStreamOptions) => {
     switch (networkType) {
       case StreamNetwork.EVM:
-        return fetcher({ ...options });
+        return evmFetcher({ ...options });
       default:
         if (networkType === undefined) {
-          return fetcher({ ...options });
+          return evmFetcher({ ...options });
         }
         throw new IncorrectNetworkError(networkType);
     }

--- a/packages/streams/src/methods/delete.ts
+++ b/packages/streams/src/methods/delete.ts
@@ -3,23 +3,21 @@ import { StreamNetwork } from '../utils/StreamNetwork';
 import { IncorrectNetworkError } from '../utils/IncorrectNetworkError';
 import Core from '@moralisweb3/common-core';
 import { deleteStreamEvmOperation, DeleteStreamEvmRequest } from '@moralisweb3/common-streams-utils';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface DeleteStreamEvmOptions extends DeleteStreamEvmRequest {
-  networkType?: 'evm';
-}
-
+export interface DeleteStreamEvmOptions extends DeleteStreamEvmRequest, CommonStreamNetworkOptions {}
 export type DeleteStreamOptions = DeleteStreamEvmOptions;
 
 export const makeDeleteStream = (core: Core, baseUrl: string) => {
-  const fetcher = new OperationResolver(deleteStreamEvmOperation, baseUrl, core).fetch;
+  const evmFetcher = new OperationResolver(deleteStreamEvmOperation, baseUrl, core).fetch;
 
   return ({ networkType, ...options }: DeleteStreamOptions) => {
     switch (networkType) {
       case StreamNetwork.EVM:
-        return fetcher({ ...options });
+        return evmFetcher({ ...options });
       default:
         if (networkType === undefined) {
-          return fetcher({ ...options });
+          return evmFetcher({ ...options });
         }
         throw new IncorrectNetworkError(networkType);
     }

--- a/packages/streams/src/methods/deleteAddress.ts
+++ b/packages/streams/src/methods/deleteAddress.ts
@@ -7,23 +7,21 @@ import {
   DeleteAddressEvmRequest,
   DeleteAddressEvmResponseAdapter,
 } from '@moralisweb3/common-streams-utils';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface DeleteAddressEvmOptions extends DeleteAddressEvmRequest {
-  networkType?: 'evm';
-}
-
+export interface DeleteAddressEvmOptions extends DeleteAddressEvmRequest, CommonStreamNetworkOptions {}
 export type DeleteAddressOptions = DeleteAddressEvmOptions;
 
 export const makeDeleteAddress = (core: Core, baseUrl: string) => {
-  const fetcher = new OperationResolver(deleteAddressEvmOperation, baseUrl, core).fetch;
+  const evmFetcher = new OperationResolver(deleteAddressEvmOperation, baseUrl, core).fetch;
 
   return ({ networkType, ...options }: DeleteAddressOptions): Promise<DeleteAddressEvmResponseAdapter> => {
     switch (networkType) {
       case StreamNetwork.EVM:
-        return fetcher({ ...options });
+        return evmFetcher({ ...options });
       default:
         if (networkType === undefined) {
-          return fetcher({ ...options });
+          return evmFetcher({ ...options });
         }
         throw new IncorrectNetworkError(networkType);
     }

--- a/packages/streams/src/methods/getAddresses.ts
+++ b/packages/streams/src/methods/getAddresses.ts
@@ -7,10 +7,9 @@ import {
   GetAddressesEvmResponseAdapter,
 } from '@moralisweb3/common-streams-utils';
 import Core from '@moralisweb3/common-core';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface GetAddressesEvmOptions extends GetAddressesEvmRequest {
-  networkType?: 'evm';
-}
+export interface GetAddressesEvmOptions extends GetAddressesEvmRequest, CommonStreamNetworkOptions {}
 
 export type GetAddressesOptions = GetAddressesEvmOptions;
 

--- a/packages/streams/src/methods/getAll.ts
+++ b/packages/streams/src/methods/getAll.ts
@@ -3,10 +3,9 @@ import { PaginatedOperationResolver } from '@moralisweb3/api-utils';
 import { getStreamsEvmOperation, GetStreamsEvmRequest } from '@moralisweb3/common-streams-utils';
 import { StreamNetwork } from '../utils/StreamNetwork';
 import { IncorrectNetworkError } from '../utils/IncorrectNetworkError';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface GetStreamsEvmOptions extends GetStreamsEvmRequest {
-  networkType?: 'evm';
-}
+export interface GetStreamsEvmOptions extends GetStreamsEvmRequest, CommonStreamNetworkOptions {}
 
 export type GetStreamsOptions = GetStreamsEvmOptions;
 

--- a/packages/streams/src/methods/getById.ts
+++ b/packages/streams/src/methods/getById.ts
@@ -1,11 +1,13 @@
 import Core from '@moralisweb3/common-core';
 import { OperationResolver } from '@moralisweb3/api-utils';
-import { StreamNetwork } from '../utils/StreamNetwork';
+import { StreamNetwork, StreamNetworkUnion } from '../utils/StreamNetwork';
 import { IncorrectNetworkError } from '../utils/IncorrectNetworkError';
 import { getStreamEvmOperation, GetStreamEvmRequest } from '@moralisweb3/common-streams-utils';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface GetStreamEvmOptions extends GetStreamEvmRequest {
-  network: 'evm';
+export interface GetStreamEvmOptions extends GetStreamEvmRequest, CommonStreamNetworkOptions {
+  /** @deprecared use networkType instead */
+  network?: StreamNetworkUnion;
 }
 
 export type GetStreamOptions = GetStreamEvmOptions;
@@ -13,12 +15,20 @@ export type GetStreamOptions = GetStreamEvmOptions;
 export const makeGetStreamById = (core: Core, baseUrl: string) => {
   const evmFetcher = new OperationResolver(getStreamEvmOperation, baseUrl, core).fetch;
 
-  return ({ network, ...options }: GetStreamOptions) => {
-    switch (network) {
+  return ({ networkType, network, ...options }: GetStreamOptions) => {
+    // Backwards compatibility for the 'network' parameter
+    if (!networkType && network) {
+      networkType = network;
+    }
+
+    switch (networkType) {
       case StreamNetwork.EVM:
         return evmFetcher({ ...options });
       default:
-        throw new IncorrectNetworkError(network);
+        if (networkType === undefined) {
+          return evmFetcher({ ...options });
+        }
+        throw new IncorrectNetworkError(networkType);
     }
   };
 };

--- a/packages/streams/src/methods/update.ts
+++ b/packages/streams/src/methods/update.ts
@@ -3,23 +3,22 @@ import { StreamNetwork } from '../utils/StreamNetwork';
 import { IncorrectNetworkError } from '../utils/IncorrectNetworkError';
 import { updateStreamEvmOperation, UpdateStreamEvmRequest } from '@moralisweb3/common-streams-utils';
 import Core from '@moralisweb3/common-core';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface UpdateStreamEvmOptions extends UpdateStreamEvmRequest {
-  networkType?: 'evm';
-}
+export interface UpdateStreamEvmOptions extends UpdateStreamEvmRequest, CommonStreamNetworkOptions {}
 
 export type UpdateStreamOptions = UpdateStreamEvmOptions;
 
 export const makeUpdateStream = (core: Core, baseUrl: string) => {
-  const fetcher = new OperationResolver(updateStreamEvmOperation, baseUrl, core).fetch;
+  const evmFetcher = new OperationResolver(updateStreamEvmOperation, baseUrl, core).fetch;
 
   return ({ networkType, ...options }: UpdateStreamOptions) => {
     switch (networkType) {
       case StreamNetwork.EVM:
-        return fetcher({ ...options });
+        return evmFetcher({ ...options });
       default:
         if (networkType === undefined) {
-          return fetcher({ ...options });
+          return evmFetcher({ ...options });
         }
         throw new IncorrectNetworkError(networkType);
     }

--- a/packages/streams/src/methods/updateStatus.ts
+++ b/packages/streams/src/methods/updateStatus.ts
@@ -3,23 +3,22 @@ import Core from '@moralisweb3/common-core';
 import { updateStreamStatusEvmOperation, UpdateStreamStatusEvmRequest } from '@moralisweb3/common-streams-utils';
 import { IncorrectNetworkError } from '../utils/IncorrectNetworkError';
 import { StreamNetwork } from '../utils/StreamNetwork';
+import { CommonStreamNetworkOptions } from '../utils/commonNetworkOptions';
 
-export interface UpdateStreamEvmStatusOptions extends UpdateStreamStatusEvmRequest {
-  networkType?: 'evm';
-}
+export interface UpdateStreamEvmStatusOptions extends UpdateStreamStatusEvmRequest, CommonStreamNetworkOptions {}
 
 export type UpdateStreamStatusOptions = UpdateStreamEvmStatusOptions;
 
 export const makeUpdateStreamStatus = (core: Core, baseUrl: string) => {
-  const fetcher = new OperationResolver(updateStreamStatusEvmOperation, baseUrl, core).fetch;
+  const evmFetcher = new OperationResolver(updateStreamStatusEvmOperation, baseUrl, core).fetch;
 
   return ({ networkType, ...options }: UpdateStreamStatusOptions) => {
     switch (networkType) {
       case StreamNetwork.EVM:
-        return fetcher({ ...options });
+        return evmFetcher({ ...options });
       default:
         if (networkType === undefined) {
-          return fetcher({ ...options });
+          return evmFetcher({ ...options });
         }
         throw new IncorrectNetworkError(networkType);
     }

--- a/packages/streams/src/utils/StreamNetwork.ts
+++ b/packages/streams/src/utils/StreamNetwork.ts
@@ -1,4 +1,4 @@
 export enum StreamNetwork {
   EVM = 'evm',
-  SOLANA = 'solana',
 }
+export type StreamNetworkUnion = `${StreamNetwork}`;

--- a/packages/streams/src/utils/commonNetworkOptions.ts
+++ b/packages/streams/src/utils/commonNetworkOptions.ts
@@ -1,0 +1,5 @@
+import { StreamNetworkUnion } from '../utils/StreamNetwork';
+
+export interface CommonStreamNetworkOptions {
+  networkType?: StreamNetworkUnion;
+}


### PR DESCRIPTION
---
name: 'Pull request'
about: A new pull request
---

## New Pull Request

### Checklist

<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Moralis!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/SECURITY.md).
- [x] My code is conform the [code style](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CODE_STYLE.md)
- [x] I have made corresponding changes to the documentation
- [x] I have updated Typescript definitions when needed

### Issue Description

`getStreamById` does not default to 'evm'.

- Moved shared logic
- Default to evm for `getStreamById`
- Fix error message when wrong networkType is provided, as we don't support Solana for streams
- deprecate network option in favour of networkType for `getStreamById` for consistency with other streams/auth methods