### PR TITLE
fix: optional `chains` property for the EVM Streams API.

### DIFF
--- a/.changeset/funny-rocks-invent.md
+++ b/.changeset/funny-rocks-invent.md
@@ -1,0 +1,6 @@
+---
+'@moralisweb3/common-streams-utils': patch
+'@moralisweb3/streams': patch
+---
+
+The `update` method for the EVM Streams API has the `chains` property optional now.

--- a/packages/common/streamsUtils/src/operations/evmStreams/updateStreamEvmOperation.test.ts
+++ b/packages/common/streamsUtils/src/operations/evmStreams/updateStreamEvmOperation.test.ts
@@ -3,7 +3,7 @@ import { CommonEvmUtils, CommonEvmUtilsConfig, EvmAddress, EvmChain } from '@mor
 import { StreamTrigger } from '../../dataTypes';
 import { updateStreamEvmOperation, UpdateStreamEvmRequest } from './updateStreamEvmOperation';
 
-describe('createStreamEvmOperation', () => {
+describe('updateStreamEvmOperation', () => {
   let core: MoralisCore;
 
   beforeAll(() => {
@@ -101,7 +101,7 @@ describe('createStreamEvmOperation', () => {
     expect(deserializedRequest.includeNativeTxs).toBe(true);
     expect(deserializedRequest.includeContractLogs).toBe(true);
     expect(deserializedRequest.includeInternalTxs).toBe(true);
-    expect((deserializedRequest.chains[0] as EvmChain).apiHex).toContain('0x1');
+    expect((deserializedRequest.chains as EvmChain[])[0].apiHex).toContain('0x1');
     expect(deserializedRequest.abi).toBe(null);
     expect(deserializedRequest.advancedOptions).toBe(null);
     expect(deserializedRequest.demo).toBe(true);

--- a/packages/common/streamsUtils/src/operations/evmStreams/updateStreamEvmOperation.ts
+++ b/packages/common/streamsUtils/src/operations/evmStreams/updateStreamEvmOperation.ts
@@ -14,7 +14,7 @@ type SuccessResponse = operations[OperationId]['responses']['200']['content']['a
 // Exports
 
 export interface UpdateStreamEvmRequest extends Camelize<Omit<RequestParams, 'chainIds' | 'triggers'>> {
-  chains: EvmChainish[];
+  chains?: EvmChainish[];
   triggers?: StreamTriggerish[];
 }
 
@@ -83,7 +83,7 @@ function getRequestBody(request: UpdateStreamEvmRequest, core: Core) {
     includeContractLogs: request.includeContractLogs,
     includeInternalTxs: request.includeInternalTxs,
     getNativeBalances: request.getNativeBalances,
-    chainIds: request.chains.map((chain) => EvmChain.create(chain, core).apiHex),
+    chainIds: request.chains?.map((chain) => EvmChain.create(chain, core).apiHex),
     abi: request.abi,
     advancedOptions: request.advancedOptions,
     demo: request.demo,
@@ -106,7 +106,7 @@ function serializeRequest(request: UpdateStreamEvmRequest, core: Core) {
     includeNativeTxs: request.includeNativeTxs,
     includeContractLogs: request.includeContractLogs,
     includeInternalTxs: request.includeInternalTxs,
-    chainIds: request.chains.map((chain) => EvmChain.create(chain, core).apiHex),
+    chainIds: request.chains?.map((chain) => EvmChain.create(chain, core).apiHex),
     abi: request.abi,
     advancedOptions: request.advancedOptions,
     demo: request.demo,
@@ -125,7 +125,7 @@ function deserializeRequest(jsonRequest: UpdateStreamEvmJSONRequest, core: Core)
     includeNativeTxs: jsonRequest.includeNativeTxs,
     includeContractLogs: jsonRequest.includeContractLogs,
     includeInternalTxs: jsonRequest.includeInternalTxs,
-    chains: jsonRequest.chainIds.map((chainId) => EvmChain.create(chainId, core)),
+    chains: jsonRequest.chainIds?.map((chainId) => EvmChain.create(chainId, core)),
     abi: jsonRequest.abi,
     advancedOptions: jsonRequest.advancedOptions,
     demo: jsonRequest.demo,

--- a/packages/streams/integration/mocks/endpoints/evm/updateStream.ts
+++ b/packages/streams/integration/mocks/endpoints/evm/updateStream.ts
@@ -37,7 +37,15 @@ export const mockUpdateStreamEvm = MockScenarios.create(
       },
       response: createEvmStreamResponse('test-1'),
     },
-
+    {
+      condition: {
+        id: 'REQUEST_WITH_NO_CHAINS',
+        tag: 'test-1',
+        description: 'Valid request',
+        webhookUrl: 'https://webhook.site/4f1b1b1b-1b1b-4f1b-1b1b-1b1b1b1b1b1b',
+      },
+      response: createEvmStreamResponse('test-no-chains'),
+    },
     {
       condition: {
         id: 'VALID_FULL_REQUEST',

--- a/packages/streams/integration/test/updateStream.test.ts
+++ b/packages/streams/integration/test/updateStream.test.ts
@@ -116,6 +116,18 @@ describe('Update stream', () => {
       expect(result.result.tag).toEqual('test-1');
     });
 
+    it('updates a stream when chains property is not provided', async () => {
+      const result = (await StreamApi.update({
+        tag: 'test-1',
+        description: 'Valid request',
+        webhookUrl: 'https://webhook.site/4f1b1b1b-1b1b-4f1b-1b1b-1b1b1b1b1b1b',
+        id: 'REQUEST_WITH_NO_CHAINS',
+      })) as UpdateStreamEvmResponseAdapter;
+
+      expect(result).toBeDefined();
+      expect(result.result.tag).toEqual('test-no-chains');
+    });
+
     it('should throw an error on invalid chain', async () => {
       const failedResult = await StreamApi.update({
         chains: ['0x3'],


### PR DESCRIPTION
---
name: fix: optional `chains` property for the EVM Streams API.
---